### PR TITLE
Install apache-libcloud 0.15.1 version instead of 0.16.0

### DIFF
--- a/python/libcloud.sls
+++ b/python/libcloud.sls
@@ -3,6 +3,7 @@ include:
 
 apache-libcloud:
   pip.installed:
+    - name: apache-libcloud==0.15.1
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Currently the openstack driver isn't working for cloud testing when using 0.16.0

See report in https://github.com/saltstack/salt/issues/20090

Once that gets fixed, we should go back to installed 0.16.0.