### PR TITLE
Ensure NPM and Bower are installed for performing integration tests

### DIFF
--- a/bower.sls
+++ b/bower.sls
@@ -1,0 +1,9 @@
+{% if grains['kernel'] == 'Linux' %}
+
+bower:
+  npm.installed:
+    - require:
+      - pkg: npm
+      - pkg: git
+
+{% endif %}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -109,6 +109,8 @@ clone-salt-repo:
       - cmd: python-zypp
       {%- endif %}
       - pip: dnspython
+      - pkg: npm
+      - npm: bower
 
 {% if test_git_url != "https://github.com/saltstack/salt.git" %}
 {#- Add Salt Upstream Git Repo #}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -49,6 +49,8 @@ include:
   {%- endif %}
   - python.mysqldb
   - python.dns
+  - npm
+  - bower
 
 /testing:
   file.directory

--- a/npm.sls
+++ b/npm.sls
@@ -7,7 +7,8 @@
   {%- set npm = 'npm' %}
 {% endif %}
 
-{{ npm }}:
-  pkg.installed
+npm:
+  pkg.installed:
+    - name: {{ npm }}
 
 {% endif %}


### PR DESCRIPTION
This pull request adds states to perform integration tests for https://github.com/saltstack/salt/pull/20875.

P.S. I hope I did right when put `npm` and `bower` to include in git/salt.sls, as there is no top.ls file here. I have noticed that some contributors add states (e.g. mysql, supervisor) to include in the same place.