### PR TITLE
Install nodejs-legacy on Ubuntu in order to execute Bower

### DIFF
--- a/bower.sls
+++ b/bower.sls
@@ -1,9 +1,17 @@
 {% if grains['kernel'] == 'Linux' %}
 
+{% if grains['os'] == 'Ubuntu' %}
+nodejs-legacy:
+    pkg.installed
+{% endif %}
+
 bower:
   npm.installed:
     - require:
       - pkg: npm
       - pkg: git
+      {% if grains['os'] == 'Ubuntu' %}
+      - pkg: nodejs-legacy
+      {% endif %}
 
 {% endif %}


### PR DESCRIPTION
This pull request adds a `nodes-legacy` pkg.installed state on Ubuntu in order to execute Bower without errors. The problem is described in https://github.com/saltstack/salt/pull/20901.