### PR TITLE
Don't require npm and bower on Ubuntu 10 and 12

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -49,8 +49,10 @@ include:
   {%- endif %}
   - python.mysqldb
   - python.dns
+  {%- if grains['os'] != 'Ubuntu' or (grains['os'] == 'Ubuntu' and not grains['osrelease'].startswith('14.') %}
   - npm
   - bower
+  {%- endif %}
 
 /testing:
   file.directory

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -111,8 +111,10 @@ clone-salt-repo:
       - cmd: python-zypp
       {%- endif %}
       - pip: dnspython
+      {%- if grains['os'] != 'Ubuntu' or (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('14.')) %}
       - pkg: npm
       - npm: bower
+      {%- endif %}
 
 {% if test_git_url != "https://github.com/saltstack/salt.git" %}
 {#- Add Salt Upstream Git Repo #}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -49,7 +49,7 @@ include:
   {%- endif %}
   - python.mysqldb
   - python.dns
-  {%- if grains['os'] != 'Ubuntu' or (grains['os'] == 'Ubuntu' and not grains['osrelease'].startswith('14.') %}
+  {%- if grains['os'] != 'Ubuntu' or (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('14.') %}
   - npm
   - bower
   {%- endif %}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -49,7 +49,7 @@ include:
   {%- endif %}
   - python.mysqldb
   - python.dns
-  {%- if grains['os'] != 'Ubuntu' or (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('14.') %}
+  {%- if grains['os'] != 'Ubuntu' or (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('14.')) %}
   - npm
   - bower
   {%- endif %}


### PR DESCRIPTION
Ubuntu 10 and 12 don't have an version of npm that is new enough to support the npm state. We'll just have to run those tests on the other distros.