### PR TITLE
Added --no-gpgcheck to nodejs repo on opensuse.

### DIFF
--- a/npm.sls
+++ b/npm.sls
@@ -11,7 +11,7 @@
 {%- if grains['os'] == 'openSUSE' %}
 install-suse-repo:
   cmd.run:
-    - name: zypper --non-interactive addrepo --refresh http://download.opensuse.org/repositories/devel:/languages:/nodejs/openSUSE_13.1/devel:languages:nodejs.repo
+    - name: zypper --non-interactive addrepo --no-gpgcheck --refresh http://download.opensuse.org/repositories/devel:/languages:/nodejs/openSUSE_13.1/devel:languages:nodejs.repo
 {% endif %}
 
 


### PR DESCRIPTION
This will fix the installation of nodejs version 12 from the repo
it failed because of the gpg check needs interaction.

Because this is run on jenkins cloud with a new vm each time,
we shouldn't care about gpg checking here.

in reference of #73 