### PR TITLE
Fix azure pip install for cloud tests

### DIFF
--- a/cloud-only/azure.sls
+++ b/cloud-only/azure.sls
@@ -3,7 +3,7 @@ include:
 
 azure:
   pip.installed:
-    {%- if (grains['os'] != 'CentOS' %}
+    {%- if (grains['os'] == 'CentOS') %}
     - name: azure==0.8.3
     {%- else %}
     - name: azure

--- a/cloud-only/azure.sls
+++ b/cloud-only/azure.sls
@@ -3,7 +3,12 @@ include:
 
 azure:
   pip.installed:
-    {%- if salt['config.get']('virtualenv_path', None)  %}
+    {%- if (grains['os'] != 'CentOS' %}
+    - name: azure==0.8.3
+    {%- else %}
+    - name: azure
+    {%- endif %}
+    {%- if salt['config.get']('virtualenv_path', None) %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
     - require:


### PR DESCRIPTION
The new azure SDK is failing during pip install (gcc errors ) on CentOS 7 VMs, likely due to an older version of gcc shipping with these images. Ubuntu 14.04 is working fine. 

After scouting around for a way to update the version of gcc on these images, and running into many problems, this is the quick fix for now.