### PR TITLE
Add 'force_checkout' to try to make checkouts across branches

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -61,6 +61,7 @@ clone-salt-repo:
   git.latest:
     - name: {{ test_git_url }}
     - always_fetch: True
+    - force_checkout: True
     - rev: {{ pillar.get('test_git_commit', 'develop') }}
     - target: /testing
     - require:


### PR DESCRIPTION
git.latest seems not to want to checkout via SHA if there is already a checkout there.  force_checkout and always_fetch seem to fix that.