### PR TITLE
Add tornado state to cloud-only init file

### DIFF
--- a/cloud-only/init.sls
+++ b/cloud-only/init.sls
@@ -13,6 +13,7 @@ include:
   - python.libcloud
   - python.requests
   - python.keyring
+  - python.tornado
   - cloud-only.azure
   - cloud-only.sshpass
 
@@ -39,6 +40,7 @@ include:
       - pip: requests
       - pip: keyring
       - pip: azure
+      - pip: tornado
       - pkg: sshpass
 
 {% if test_git_url != "https://github.com/saltstack/salt.git" %}


### PR DESCRIPTION
This will fix the cloud test stacktraces on the develop branch