### PR TITLE
add python-dev to debian 7 pip dependencies

### DIFF
--- a/python/pip.sls
+++ b/python/pip.sls
@@ -12,6 +12,9 @@ include:
   {% if grains['os_family'] == 'RedHat' and grains['osmajorrelease'][0] == '5' %}
   - python26
   {% endif %}
+{%- if grains['os_family'] == 'Debian' and grains['osmajorrelease'][0] == '7' %}
+  - python.headers
+{% endif %}
 
 pip-install:
   cmd.run:
@@ -26,4 +29,7 @@ pip-install:
       - pkg: curl
       {% if grains['os_family'] == 'RedHat' and grains['osmajorrelease'][0] == '5' %}
       - python26
+      {% endif %}
+      {% if grains['os_family'] == 'Debian' and grains['osmajorrelease'][0] == '7' %}
+      - python-dev
       {% endif %}


### PR DESCRIPTION
I'm hoping this will resolve this error during debian 7 bootstrap:
```
16:27:23 Configure: Autodetecting ZMQ settings...
16:27:23     Custom ZMQ dir:       
16:27:23 build/temp.linux-x86_64-2.7/scratch/tmp/easy_install-jEB0Kg/pyzmq-14.6.0/temp/timer_create1xD8Sh.o: In function `main':
16:27:23 timer_create1xD8Sh.c:(.text+0x15): undefined reference to `timer_create'
16:27:23 collect2: error: ld returned 1 exit status
16:27:23     ZMQ version detected: 3.2.3
16:27:23 Warning: Detected ZMQ version: 3.2.3, but pyzmq targets ZMQ 4.0.5.
16:27:23 Warning: libzmq features and fixes introduced after 3.2.3 will be unavailable.
16:27:23 zmq/devices/monitoredqueue.c:16:20: fatal error: Python.h: No such file or directory
16:27:23 compilation terminated.
```