### PR TITLE
Update pycrypto version for CentOS <= 6 so we can run the test daemons

### DIFF
--- a/centos_pycrypto.sls
+++ b/centos_pycrypto.sls
@@ -1,0 +1,12 @@
+# Until pycrypto>=2.6.1 can be packaged, we need to be able to run the test suite on CentOS 5/6
+
+uninstall_system_pycrypto:
+  pkg.removed:
+    - name: python-crypto
+
+new_pycrypto:
+  pip.installed:
+    - name: pycrypto >= 2.6.1
+    - require:
+      - pkg: uninstall_system_pycrypto
+      - cmd: pip-install

--- a/centos_pycrypto.sls
+++ b/centos_pycrypto.sls
@@ -8,4 +8,5 @@ new_pycrypto:
   pip.installed:
     - name: pycrypto >= 2.6.1
     - require:
+      - pkg: uninstall_system_pycrypto
       - cmd: pip-install

--- a/centos_pycrypto.sls
+++ b/centos_pycrypto.sls
@@ -8,5 +8,4 @@ new_pycrypto:
   pip.installed:
     - name: pycrypto >= 2.6.1
     - require:
-      - pkg: uninstall_system_pycrypto
       - cmd: pip-install

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -57,6 +57,9 @@ include:
   - npm
   - bower
   {%- endif %}
+  {%- if grains['os'] == CentOS and grains['osmajorrelease'] <= 6 %}
+  - centos_pycrypto
+  {%- endif %}
 
 /testing:
   file.directory
@@ -124,6 +127,10 @@ clone-salt-repo:
       {%- if (grains['os'] not in ['Debian', 'Ubuntu', 'openSUSE'] and not grains['osrelease'].startswith('5.')) or (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('14.')) %}
       - pkg: npm
       - npm: bower
+      {%- endif %}
+      {%- if grains['os'] == CentOS and grains['osmajorrelease'] <= 6 %}
+      pkg: uninstall_system_pycrypto
+      pip: new_pycrypto
       {%- endif %}
 
 {% if test_git_url != "https://github.com/saltstack/salt.git" %}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -57,7 +57,7 @@ include:
   - npm
   - bower
   {%- endif %}
-  {%- if grains['os'] == 'CentOS' and grains['osmajorrelease'] <= 6 %}
+  {%- if grains['os'] == 'CentOS' and (grains['osmajorrelease'] == '6' or grains['osmajorrelease'] == '5') %}
   - centos_pycrypto
   {%- endif %}
 
@@ -128,7 +128,7 @@ clone-salt-repo:
       - pkg: npm
       - npm: bower
       {%- endif %}
-      {%- if grains['os'] == 'CentOS' and grains['osmajorrelease'] <= 6 %}
+  {%- if grains['os'] == 'CentOS' and (grains['osmajorrelease'] == '6' or grains['osmajorrelease'] == '5') %}
       pkg: uninstall_system_pycrypto
       pip: new_pycrypto
       {%- endif %}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -129,8 +129,8 @@ clone-salt-repo:
       - npm: bower
       {%- endif %}
       {%- if grains['os'] == 'CentOS' and (grains['osmajorrelease'] == '6' or grains['osmajorrelease'] == '5') %}
-      pkg: uninstall_system_pycrypto
-      pip: new_pycrypto
+      - pkg: uninstall_system_pycrypto
+      - pip: new_pycrypto
       {%- endif %}
 
 {% if test_git_url != "https://github.com/saltstack/salt.git" %}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -57,7 +57,7 @@ include:
   - npm
   - bower
   {%- endif %}
-  {%- if grains['os'] == CentOS and grains['osmajorrelease'] <= 6 %}
+  {%- if grains['os'] == 'CentOS' and grains['osmajorrelease'] <= 6 %}
   - centos_pycrypto
   {%- endif %}
 
@@ -128,7 +128,7 @@ clone-salt-repo:
       - pkg: npm
       - npm: bower
       {%- endif %}
-      {%- if grains['os'] == CentOS and grains['osmajorrelease'] <= 6 %}
+      {%- if grains['os'] == 'CentOS' and grains['osmajorrelease'] <= 6 %}
       pkg: uninstall_system_pycrypto
       pip: new_pycrypto
       {%- endif %}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -128,7 +128,7 @@ clone-salt-repo:
       - pkg: npm
       - npm: bower
       {%- endif %}
-  {%- if grains['os'] == 'CentOS' and (grains['osmajorrelease'] == '6' or grains['osmajorrelease'] == '5') %}
+      {%- if grains['os'] == 'CentOS' and (grains['osmajorrelease'] == '6' or grains['osmajorrelease'] == '5') %}
       pkg: uninstall_system_pycrypto
       pip: new_pycrypto
       {%- endif %}


### PR DESCRIPTION
Fixes the errors from CentOS 6 tests on the develop branch.

Refs https://github.com/saltstack/salt/pull/24051 