### PR TITLE
Update pycrypto to 2.6.1 everywhere

### DIFF
--- a/centos_pycrypto.sls
+++ b/centos_pycrypto.sls
@@ -1,4 +1,6 @@
 # Until pycrypto>=2.6.1 can be packaged, we need to be able to run the test suite on CentOS 5/6
+include:
+  - python.pycrypto
 
 uninstall_system_pycrypto:
   pkg.removed:

--- a/centos_pycrypto.sls
+++ b/centos_pycrypto.sls
@@ -3,10 +3,5 @@
 uninstall_system_pycrypto:
   pkg.removed:
     - name: python-crypto
-
-new_pycrypto:
-  pip.installed:
-    - name: pycrypto >= 2.6.1
-    - require:
-      - pkg: uninstall_system_pycrypto
-      - cmd: pip-install
+    - require_in:
+      - pip: pycrypto

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -36,6 +36,7 @@ include:
   - python.moto
   - python.psutil
   - python.tornado
+  - python.pycrypto
   {%- if grains.get('pythonversion')[:2] < [3, 2] %}
   - python.futures
   {%- endif %}
@@ -106,6 +107,7 @@ clone-salt-repo:
       - pip: moto
       - pip: psutil
       - pip: tornado
+      - pip: pycrypto
       {%- if grains.get('pythonversion')[:2] < [3, 2] %}
       - pip: futures
       {%- endif %}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -130,7 +130,6 @@ clone-salt-repo:
       {%- endif %}
       {%- if grains['os'] == 'CentOS' and (grains['osmajorrelease'] == '6' or grains['osmajorrelease'] == '5') %}
       - pkg: uninstall_system_pycrypto
-      - pip: new_pycrypto
       {%- endif %}
 
 {% if test_git_url != "https://github.com/saltstack/salt.git" %}

--- a/python/pycrypto.sls
+++ b/python/pycrypto.sls
@@ -4,6 +4,7 @@ include:
 
 pycrypto:
   pip.installed:
+    - name: pycrypto >= 2.6.1
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Previously only CenotOS 5 and 6 were updated, but more distros like Ubuntu 12 need pycrypto updated to 2.6.1 as well.