### PR TITLE
removing six to avoid error when installing pyopenssl. 

### DIFF
--- a/pyopenssl.sls
+++ b/pyopenssl.sls
@@ -8,6 +8,12 @@
   {% set pyopenssl = 'python2-pyopenssl' %}
 {% endif %}
 
+{% if grains['os'] == 'Arch' %}
+six:
+  pip.removed:
+    - name: six
+{% endif %} 
+
 pyopenssl:
   pkg.installed:
     - name: {{ pyopenssl }}


### PR DESCRIPTION
pyopenssl installs six during the install process. This eliminates the error where six already exists on the file system. 