### PR TITLE
Bandaid fix to update msgpack

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -112,7 +112,6 @@ clone-salt-repo:
       - pip: tornado
       - pip: pycrypto
       - pip: pyinotify
-      - pip: msgpack
       - pkg: pyopenssl
       {%- if grains.get('pythonversion')[:2] < [3, 2] %}
       - pip: futures

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -38,6 +38,7 @@ include:
   - python.tornado
   - python.pycrypto
   - python.pyinotify
+  - python.msgpack
   - pyopenssl
   {%- if grains.get('pythonversion')[:2] < [3, 2] %}
   - python.futures
@@ -111,6 +112,7 @@ clone-salt-repo:
       - pip: tornado
       - pip: pycrypto
       - pip: pyinotify
+      - pip: python-msgpack
       - pkg: pyopenssl
       {%- if grains.get('pythonversion')[:2] < [3, 2] %}
       - pip: futures

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -112,7 +112,7 @@ clone-salt-repo:
       - pip: tornado
       - pip: pycrypto
       - pip: pyinotify
-      - pip: python-msgpack
+      - pip: msgpack
       - pkg: pyopenssl
       {%- if grains.get('pythonversion')[:2] < [3, 2] %}
       - pip: futures

--- a/python/msgpack.sls
+++ b/python/msgpack.sls
@@ -7,6 +7,7 @@ msgpack-python:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
+    - name: msgpack-python > 0.3
     - index_url: https://pypi-jenkins.saltstack.com/jenkins/develop
     - extra_index_url: https://pypi.python.org/simple
     - require:


### PR DESCRIPTION
This should work to get msgpack updated on ubuntu 12 and debian 7. It's kind of a bandaid fix because msgpack isn't getting a good version from the system, even though the requirements.txt file has >3.0 in it. Both installing from package manger and bootstrap have this problem. 