### PR TITLE
A couple of fixes

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -70,6 +70,9 @@ include:
   {%- if grains['os'] == 'Fedora' and (grains['os'] == 'CentOS' and grains['osmajorrelease'] == '5') %}
   - gpg
   {%- endif %}
+  {%- if grains['os'] == 'Fedora' and grains['osrelease'] == '22' %}
+  - versionlock
+  {% endif %}
 
 /testing:
   file.directory

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -144,7 +144,7 @@ clone-salt-repo:
       {%- if grains['os'] == 'CentOS' and (grains['osmajorrelease'] == '6' or grains['osmajorrelease'] == '5') %}
       - pkg: uninstall_system_pycrypto
       {%- endif %}
-      {%- if grains['os'] == 'Fedora' and (grains['os'] == 'CentOS' and grains['osmajorrelease'] == '5' %}
+      {%- if grains['os'] == 'Fedora' and (grains['os'] == 'CentOS' and grains['osmajorrelease'] == '5') %}
       - pkg: gpg
       {%- endif %}
 

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -144,8 +144,8 @@ clone-salt-repo:
       {%- if grains['os'] == 'CentOS' and (grains['osmajorrelease'] == '6' or grains['osmajorrelease'] == '5') %}
       - pkg: uninstall_system_pycrypto
       {%- endif %}
-      {%- if grains['os'] == 'Fedora' %}
-      - pkg: gnupg
+      {%- if grains['os'] == 'Fedora' and (grains['os'] == 'CentOS' and grains['osmajorrelease'] == '5' %}
+      - pkg: gpg
       {%- endif %}
 
 {% if test_git_url != "https://github.com/saltstack/salt.git" %}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -145,7 +145,7 @@ clone-salt-repo:
       - pkg: uninstall_system_pycrypto
       {%- endif %}
       {%- if grains['os'] == 'Fedora' %}
-      - pkg: gpg
+      - pkg: gnupg
       {%- endif %}
 
 {% if test_git_url != "https://github.com/saltstack/salt.git" %}

--- a/versionlock.sls
+++ b/versionlock.sls
@@ -1,0 +1,5 @@
+{% if grains['os'] == 'Fedora' and grains['osrelease'] == '22' %}
+versionlock:
+  cmd.run:
+    - name: "dnf install 'dnf-command(versionlock)'"
+{% endif %}

--- a/versionlock.sls
+++ b/versionlock.sls
@@ -1,5 +1,5 @@
 {% if grains['os'] == 'Fedora' and grains['osrelease'] == '22' %}
 versionlock:
   cmd.run:
-    - name: "dnf install 'dnf-command(versionlock)'"
+    - name: "dnf install -y 'dnf-command(versionlock)'"
 {% endif %}


### PR DESCRIPTION
This should fix the failing tests on fedora 21, 22 and centos 5.

Fedora 22 uses DNF instead of yum, so versionlock needs to be installed via DNF for pkg.hold to work correctly. 