### PR TITLE
Took ioflo out of reat dependencies

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -49,9 +49,9 @@ include:
   - python.futures
   {%- endif %}
   - dnsutils
+  - python.ioflo
   {%- if test_transport == 'raet' %}
   - python.libnacl
-  - python.ioflo
   - python.raet
   {%- endif %}
   {%- if grains['os'] == 'Arch' or (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('14.')) %}
@@ -132,9 +132,9 @@ clone-salt-repo:
       - pip: gitpython
       - pkg: dnsutils
       - pkg: mysqldb
+      - pip: ioflo
       {%- if test_transport == 'raet' %}
       - pip: libnacl
-      - pip: ioflo
       - pip: raet
       {%- endif %}
       {%- if grains['os'] == 'Arch' or (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('14.')) %}


### PR DESCRIPTION
This will allow the newest version of ioflo to get installed with the rest of the jenkins deps. It will also alleviate some of the import errors we are seeing in pylint tests and pr tests. 