### PR TITLE
Keyring dropped support for python26 in v6.0

### DIFF
--- a/python/keyring.sls
+++ b/python/keyring.sls
@@ -3,6 +3,7 @@ include:
 
 keyring:
   pip.installed:
+    - name: keyring==5.7.1
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Pinning keyring at 5.7.1 until we decide what to do about python2.6 support.