### PR TITLE
Setuptools 19.4 on arch isn't recognized, for some reason

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -20,6 +20,9 @@ include:
   {#- Yes! openSuse ships xml as separate package #}
   - python.xml
   - python.hgtools
+  - python.setuptools-scm
+  {%- endif %}
+  {%- if grains['os'] == 'Arch' %}
   - python.setuptools
   {%- endif %}
   - python.mock
@@ -104,6 +107,9 @@ clone-salt-repo:
       - pkg: python-xml
       - pip: hgtools
       - pip: setuptools-scm
+      {%- endif %}
+      {%- if grains['os'] == 'Arch' %}
+      - pip: setuptools
       {%- endif %}
       - pip: SaltTesting
       - pip: virtualenv

--- a/python/setuptools-scm.sls
+++ b/python/setuptools-scm.sls
@@ -1,0 +1,3 @@
+setuptools-scm:
+  pip.installed:
+    - name: setuptools-scm

--- a/python/setuptools.sls
+++ b/python/setuptools.sls
@@ -1,3 +1,3 @@
 setuptools:
-  pip.installed:
-    - name: setuptools-scm
+  pkg.installed:
+    - name: setuptools==19.3

--- a/python/setuptools.sls
+++ b/python/setuptools.sls
@@ -1,3 +1,3 @@
 setuptools:
-  pkg.installed:
+  pip.installed:
     - name: setuptools==19.3


### PR DESCRIPTION
This places setuptools at 19.3, a last known good version, while 19.4 is investigated. 