### PR TITLE
Update python2.7 on Arch

### DIFF
--- a/python/pip.sls
+++ b/python/pip.sls
@@ -34,6 +34,9 @@ include:
   {% if on_redhat_5 %}
   - python26
   {% endif %}
+  {% if on_arch %}
+  - python27
+  {% endif %}
   {%- if on_debian_7 %}
   - python.headers
   {% endif %}

--- a/python27.sls
+++ b/python27.sls
@@ -1,0 +1,2 @@
+python2:
+  pkg.installed

--- a/python27.sls
+++ b/python27.sls
@@ -1,2 +1,2 @@
 python2:
-  pkg.installed
+  pkg.latest


### PR DESCRIPTION
Arch with python 2.7.10 will install pip correctly

```bash
File "get-pip.py", line 19154, in <module>
18:40:45     main()
18:40:45   File "get-pip.py", line 194, in main
18:40:45     bootstrap(tmpdir=tmpdir)
18:40:45   File "get-pip.py", line 82, in bootstrap
18:40:45     import pip
18:40:45   File "/tmp/tmplrbACK/pip.zip/pip/__init__.py", line 15, in <module>
18:40:45   File "/tmp/tmplrbACK/pip.zip/pip/vcs/subversion.py", line 9, in <module>
18:40:45   File "/tmp/tmplrbACK/pip.zip/pip/index.py", line 30, in <module>
18:40:45   File "/tmp/tmplrbACK/pip.zip/pip/wheel.py", line 39, in <module>
18:40:45   File "/tmp/tmplrbACK/pip.zip/pip/_vendor/distlib/scripts.py", line 14, in <module>
18:40:45   File "/tmp/tmplrbACK/pip.zip/pip/_vendor/distlib/compat.py", line 31, in <module>
18:40:45 ImportError: cannot import name HTTPSHandler```