### PR TITLE
Updated mysqldb name for opensuse

### DIFF
--- a/python/mysqldb.sls
+++ b/python/mysqldb.sls
@@ -3,7 +3,7 @@
 {% elif grains['os_family'] == 'RedHat' %}
   {% set mysqldb = 'MySQL-python' %}
 {% elif grains['os_family'] == 'Suse' %}
-  {% set mysqldb = 'python-mysql' %}
+  {% set mysqldb = 'python-MySQL-python' %}
 {% elif grains['os_family'] == 'FreeBSD' %}
   {% set mysqldb = 'py27-MySQLdb' %}
 {% else %}


### PR DESCRIPTION
Suse has weird names for python-mysql. 