### PR TITLE
Add python3 support to salt-jenkins

### DIFF
--- a/python/headers.sls
+++ b/python/headers.sls
@@ -16,6 +16,10 @@
   {% set python_dev = 'python-dev' %}
 {% endif %}
 
+{% set py3 = pillar.get('py3', False) %}
+{% if py3 and grains['os'] == 'CentOS' and grains['osrelease'].startswith('7') %}
+  {% set python_dev = 'python34-devel' %}
+{% endif %}
 
 python-dev:
   pkg.installed:

--- a/python/pip.sls
+++ b/python/pip.sls
@@ -60,6 +60,9 @@ pip-install:
     - reload_modules: True
     - require:
       - pkg: curl
+      {% if py3 %}
+      - pkg: python3
+      {% endif %}
       {% if on_redhat_5 %}
       - pkg: python26
       {% endif %}

--- a/python/pip.sls
+++ b/python/pip.sls
@@ -61,7 +61,7 @@ pip-install:
     - require:
       - pkg: curl
       {% if py3 %}
-      - pkg: python3
+      - pkg: install_python3
       {% endif %}
       {% if on_redhat_5 %}
       - pkg: python26

--- a/python/pip.sls
+++ b/python/pip.sls
@@ -21,12 +21,12 @@
   {% set on_arch = False %}
 {% endif %}
 
-{% if on_arch %}
+{% if py3 %}
+  {% set python = 'python3' %}
+{% elif on_arch %}
   {% set python = 'python2' %}
 {% elif on_redhat_5 %}
   {% set python = 'python26' %}
-{% elif on_arch and py3 %}
-  {% set python = 'python3' %}
 {% else %}
   {% set python = 'python' %}
 {% endif %}
@@ -37,7 +37,7 @@ include:
   {% if on_redhat_5 %}
   - python26
   {% endif %}
-  {% if on_arch %}
+  {% if on_arch and not py3 %}
   - python27
   {% endif %}
   {%- if on_debian_7 %}

--- a/python/pip.sls
+++ b/python/pip.sls
@@ -23,7 +23,7 @@
 
 {% if py3 %}
   {% set python = 'python3' %}
-{% elif on_arch %}
+{% elif on_arch and not py3 %}
   {% set python = 'python2' %}
 {% elif on_redhat_5 %}
   {% set python = 'python26' %}
@@ -39,6 +39,9 @@ include:
   {% endif %}
   {% if on_arch and not py3 %}
   - python27
+  {% endif %}
+  {% if py3 %}
+  - python3
   {% endif %}
   {%- if on_debian_7 %}
   - python.headers

--- a/python/pip.sls
+++ b/python/pip.sls
@@ -1,6 +1,7 @@
 {% set distro = salt['grains.get']('oscodename', '')  %}
 {% set os_family = salt['grains.get']('os_family', '') %}
 {% set os_major_release = salt['grains.get']('osmajorrelease', '') %}
+{% set py3 = pillar.get('py3', False) %}
 
 {% if os_family == 'RedHat' and os_major_release[0] == '5' %}
   {% set on_redhat_5 = True %}
@@ -24,6 +25,8 @@
   {% set python = 'python2' %}
 {% elif on_redhat_5 %}
   {% set python = 'python26' %}
+{% if on_arch and py3 %}
+  {% set python = 'python3' %}
 {% else %}
   {% set python = 'python' %}
 {% endif %}

--- a/python/pip.sls
+++ b/python/pip.sls
@@ -25,7 +25,7 @@
   {% set python = 'python2' %}
 {% elif on_redhat_5 %}
   {% set python = 'python26' %}
-{% if on_arch and py3 %}
+{% elif on_arch and py3 %}
   {% set python = 'python3' %}
 {% else %}
   {% set python = 'python' %}

--- a/python3.sls
+++ b/python3.sls
@@ -1,0 +1,2 @@
+python3:
+  pkg.latest

--- a/python3.sls
+++ b/python3.sls
@@ -1,2 +1,14 @@
-python3:
-  pkg.installed
+{% set distro = salt['grains.get']('oscodename', '')  %}
+{% set os_family = salt['grains.get']('os_family', '') %}
+{% set os_major_release = salt['grains.get']('osmajorrelease', '') %}
+
+{% if os_family == 'RedHat' and os_major_release[0] == '7' %}
+  {% set python3 = 'python34' %}
+{% else %}
+  {% set python3 == 'python3' %}
+{% endif %}
+
+
+install_python3:
+  pkg.installed:
+    - name: {{ python3 }}

--- a/python3.sls
+++ b/python3.sls
@@ -1,2 +1,2 @@
 python3:
-  pkg.latest
+  pkg.installed

--- a/python3.sls
+++ b/python3.sls
@@ -5,7 +5,7 @@
 {% if os_family == 'RedHat' and os_major_release[0] == '7' %}
   {% set python3 = 'python34' %}
 {% else %}
-  {% set python3 == 'python3' %}
+  {% set python3 = 'python3' %}
 {% endif %}
 
 

--- a/python3.sls
+++ b/python3.sls
@@ -4,6 +4,8 @@
 
 {% if os_family == 'RedHat' and os_major_release[0] == '7' %}
   {% set python3 = 'python34' %}
+{% elif os_family == 'Arch' %}
+  {% set python3 = 'python' %}
 {% else %}
   {% set python3 = 'python3' %}
 {% endif %}


### PR DESCRIPTION
This lets python3 be used if the python3 pillar is set to true. 

Example:
```bash
salt '*' state.sls git.salt pillar="{'py3': True}"
```

In salt-testing, python3 support is being added here: https://github.com/saltstack/salt-testing/pull/56. This lets jenkins pass in `--test-with-python3` to salt-jenkins-build which will set the py3 pillar. 