### PR TITLE
Add version to python26-devel so centos5

### DIFF
--- a/python/headers.sls
+++ b/python/headers.sls
@@ -25,5 +25,5 @@ python-dev:
   pkg.installed:
     - name: {{ python_dev }}
     {% if grains['os'] == 'CentOS' and grains['osrelease'].startswith('5') %}
-    - version: 2.6.8-3.el5
+    - version: 0:2.6.8-3.el5
     {% endif %}

--- a/python/headers.sls
+++ b/python/headers.sls
@@ -3,7 +3,7 @@
     {% set python_dev = 'python-devel' %}
   {% elif grains['os'] == 'CentOS' %}
     {% if grains['osrelease'].startswith('5') %}
-      {% set python_dev = 'python26-devel-2.6.8-3.el5' %}
+      {% set python_dev = 'python26-devel' %}
     {% else %}
       {% set python_dev = 'python-devel' %}
     {% endif %}
@@ -24,3 +24,6 @@
 python-dev:
   pkg.installed:
     - name: {{ python_dev }}
+    {% if grains['os'] == 'CentOS' and grains['osrelease'].startswith('5') %}
+    - version: 2.6.8-3.el5
+    {% endif %}

--- a/python/headers.sls
+++ b/python/headers.sls
@@ -3,7 +3,7 @@
     {% set python_dev = 'python-devel' %}
   {% elif grains['os'] == 'CentOS' %}
     {% if grains['osrelease'].startswith('5') %}
-      {% set python_dev = 'python26-devel' %}
+      {% set python_dev = 'python26-devel-2.6.8-3.el5' %}
     {% else %}
       {% set python_dev = 'python-devel' %}
     {% endif %}


### PR DESCRIPTION
Centos5 seems to be having a problem installing python26-devel due to versioning mismatch. pinning the version on centos5 fixes this. 