### PR TITLE
Specify saltstack repo to install python-dev on centos5

### DIFF
--- a/python/headers.sls
+++ b/python/headers.sls
@@ -25,5 +25,5 @@ python-dev:
   pkg.installed:
     - name: {{ python_dev }}
     {% if grains['os'] == 'CentOS' and grains['osrelease'].startswith('5') %}
-    - version: latest
+    - fromrepo: saltstack
     {% endif %}


### PR DESCRIPTION
For some reason pyhon26-devel is pulling from epel, not saltstack repo. If we're on centos5, this ensures we are getting the right python26-devel version. 