### PR TITLE
git.salt: force reset

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -124,6 +124,7 @@ clone-salt-repo:
     - name: {{ test_git_url }}
     - always_fetch: True
     - force_checkout: True
+    - force_reset: True
     - rev: {{ pillar.get('test_git_commit', 'develop') }}
     - target: /testing
     - require:


### PR DESCRIPTION
Force reset the `/testing` repo if it is already checked out and the update is not a fast-forward.