### PR TITLE
Upgrade certifi packages on Suse

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -31,7 +31,7 @@ include:
   - python.setuptools
   {%- endif %}
   {% if grains['os_family'] == 'Suse' %}
-  - pip: certifi
+  - python.certifi
   {% endif %}
   - python.six
   - python.mock

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -30,6 +30,9 @@ include:
   {%- if grains['os'] == 'Arch' %}
   - python.setuptools
   {%- endif %}
+  {% if grains['os_family'] == 'Suse' %}
+  - pip: certifi
+  {% endif %}
   - python.six
   - python.mock
   - python.timelib
@@ -155,6 +158,9 @@ clone-salt-repo:
       - pip: unittest2
       - pip: argparse
       {%- endif %}
+      {% if grains['os_family'] == 'Suse' %}
+      - pip: certifi
+      {% endif %}
       - pip: mock
       - pip: timelib
       - pip: coverage

--- a/python/certifi.sls
+++ b/python/certifi.sls
@@ -1,0 +1,13 @@
+include:
+  - python.pip
+
+certifi:
+  pip.installed:
+    {%- if salt['config.get']('virtualenv_path', None)  %}
+    - bin_env: {{ salt['config.get']('virtualenv_path') }}
+    {%- endif %}
+    - index_url: https://pypi-jenkins.saltstack.com/jenkins/develop
+    - extra_index_url: https://pypi.python.org/simple
+    - upgrade: True
+    - require:
+      - cmd: pip-install


### PR DESCRIPTION
The CherryPy pip install fails because the version of certifi on the test VMs is too old. We need to install a newer version via pip.