### PR TITLE
move openstack above psutil

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -15,6 +15,10 @@ include:
   - subversion
   {%- endif %}
   #}
+  {% if (grains['os'] in ('RedHat', 'CentOS') and grains['osrelease'].startswith('7')) or
+        (grains['os'] in ('Ubuntu') and grains['osrelease'] in ('16.04', '14.04')) %}
+  - openstack 
+  {% endif %}
   - python.salttesting
   - python.virtualenv
   {%- if grains.get('pythonversion')[:2] < [2, 7] %}
@@ -115,10 +119,6 @@ include:
   {% endif %}
   {% if python3 %}
   - python3-setup
-  {% endif %}
-  {% if (grains['os'] in ('RedHat', 'CentOS') and grains['osrelease'].startswith('7')) or
-        (grains['os'] in ('Ubuntu') and grains['osrelease'] in ('16.04', '14.04')) %}
-  - keystone
   {% endif %}
 
 /testing:

--- a/python/psutil.sls
+++ b/python/psutil.sls
@@ -23,6 +23,7 @@ include:
 
 psutil:
   pip.installed:
+    - upgrade: True
     - index_url: https://pypi-jenkins.saltstack.com/jenkins/develop
     - extra_index_url: https://pypi.python.org/simple
     - require:


### PR DESCRIPTION
This way the psutil package gets overwritten with the python update for centos 7 and redhat 7