### PR TITLE
Remove lxc install from Ubuntu 14.04

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -81,7 +81,7 @@ include:
   - python.libnacl
   - python.raet
   {%- endif %}
-  {%- if grains['os'] == 'Arch' or (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('14.')) %}
+  {%- if grains['os'] == 'Arch' %}
   - lxc
   {%- endif %}
   {%- if grains['os'] == 'openSUSE' %}


### PR DESCRIPTION
The lxc packages (I tested 3 versions on Ubuntu 14.04) have authentication errors either on the lxc package itself, or on one of the lxc dependencies when trying to install lxc. For some reason, older package versions of lxc have a new python3-lxc dependency (which fails authentication). The newer version has the same authenitcation/GPG check failure, as well as the lxc package itself.

One option to fix these and proceed with the install is to add `skip_verify: True` to the LXC state, but since that is dangerous and we don't package this our selves, let's remove this and have the lxc state only run on Arch for now.

We can re-add this state when the package installation/GPG check failures are resolved. A comment will be added to issue #240 to remember to come back around to this change.