### PR TITLE
Add Ubuntu 16 to the lxc install list

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -81,7 +81,7 @@ include:
   - python.libnacl
   - python.raet
   {%- endif %}
-  {%- if grains['os'] == 'Arch' %}
+  {%- if grains['os'] == 'Arch' or (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('16.')) %}
   - lxc
   {%- endif %}
   {%- if grains['os'] == 'openSUSE' %}


### PR DESCRIPTION
While Ubuntu 14.04 lxc packages were failing with GPG authentication failures, Ubuntu 16 packages are not failing in this way. Let's run the lxc state on Ubuntu 16 instead.

Refs #240 and #242 