### PR TITLE
Ensure GitPython < 2.0.9 installed on CentOS <= 6

### DIFF
--- a/python/gitpython.sls
+++ b/python/gitpython.sls
@@ -1,13 +1,18 @@
 include:
   - python.pip
 
-gitpython:
+GitPython:
   pip.installed:
+    {%- if grains['os'] == 'CentOS' and grains['osmajorrelease']|int <= 6 %}
+    # GitPython 2.0.9 introduced a dep on salttesting.case which is not
+    # available in Python 2.6
+    - name: 'GitPython < 2.0.9'
+    {%- endif -%}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
     - index_url: https://pypi-jenkins.saltstack.com/jenkins/develop
     - extra_index_url: https://pypi.python.org/simple
     - require:
-      - cmd: pip-install 
+      - cmd: pip-install
 


### PR DESCRIPTION
2.0.9 introduced a new dep on salttesting.case, which is not present in
Python 2.6.