### PR TITLE
fix psutils error

### DIFF
--- a/cloud-only/init.sls
+++ b/cloud-only/init.sls
@@ -21,6 +21,7 @@ include:
   {%- endif %}
   {% if on_redhat %}
   - selinux.permissive
+  - nova.pip-workaround
   {% endif %}
   - cloud-only.azure
   - cloud-only.netaddr

--- a/nova/package.sls
+++ b/nova/package.sls
@@ -1,3 +1,5 @@
+{% set on_redhat = True if grains['os_family'] == 'RedHat' else False %}
+
 {%- load_yaml as rawmap %}
 Ubuntu:
   packages:
@@ -42,3 +44,9 @@ nova packages:
   pkg.latest:
     - force_yes: True
     - pkgs: {{ nova.packages }}
+
+{% if on_redhat %}
+python-psutils:
+  pip.installed:
+    - name: psutil==2.2.1
+{% endif %}

--- a/nova/package.sls
+++ b/nova/package.sls
@@ -1,5 +1,3 @@
-{% set on_redhat = True if grains['os_family'] == 'RedHat' else False %}
-
 {%- load_yaml as rawmap %}
 Ubuntu:
   packages:
@@ -45,8 +43,3 @@ nova packages:
     - force_yes: True
     - pkgs: {{ nova.packages }}
 
-{% if on_redhat %}
-python-psutils:
-  pip.installed:
-    - name: psutil==2.2.1
-{% endif %}

--- a/nova/package.sls
+++ b/nova/package.sls
@@ -42,4 +42,3 @@ nova packages:
   pkg.latest:
     - force_yes: True
     - pkgs: {{ nova.packages }}
-

--- a/nova/pip-workaround.sls
+++ b/nova/pip-workaround.sls
@@ -1,0 +1,6 @@
+{# need to use this workaround due to a psutils version error as documented here:
+https://github.com/saltstack/salt-jenkins/pull/270#}
+
+python-psutils:
+  pip.installed:
+    - name: psutil==2.2.1


### PR DESCRIPTION
Currently the `cloud-only` states upgrade psutils via pip which currently is upgraded to version 5.

Well now that we are installing nova packages they require the psutils rpm packages which is only at version 2.2.1 in centos, and i do not see a version 5 available in the repo.

Adding this step to ensure psutils is downgraded to 2.2.1 to match the version in the package or else we will run into this error when starting nova services:

```
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: Traceback (most recent call last):
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: File "/usr/bin/nova-compute", line 6, in <module>
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: from nova.cmd.compute import main
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: File "/usr/lib/python2.7/site-packages/nova/cmd/compute.py", line 23, in <module>
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: from oslo_reports import guru_meditation_report as gmr
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: File "/usr/lib/python2.7/site-packages/oslo_reports/guru_meditation_report.py", line 73, in <module>
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: from oslo_reports.generators import process as prgen
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: File "/usr/lib/python2.7/site-packages/oslo_reports/generators/process.py", line 23, in <module>
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: import psutil
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: File "/usr/lib64/python2.7/site-packages/psutil/__init__.py", line 181, in <module>
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: raise ImportError(msg)
Nov 18 10:19:36 Zjk-cloud-cloud-cent7-42 nova-compute[8084]: ImportError: version conflict: '/usr/lib64/python2.7/site-packages/psutil/_psutil_linux.so' C extension module 
```