### PR TITLE
remove openstack recently added

### DIFF
--- a/cloud-only/init.sls
+++ b/cloud-only/init.sls
@@ -19,15 +19,10 @@ include:
   {%- if grains.get('pythonversion')[:2] < [3, 2] %}
   - python.futures
   {%- endif %}
-  {% if on_redhat %}
-  - selinux.permissive
-  - nova.pip-workaround
-  {% endif %}
   - cloud-only.azure
   - cloud-only.netaddr
   - cloud-only.profitbricks
   - cloud-only.sshpass
-  - openstack
 
 /testing:
   file.directory


### PR DESCRIPTION
After adding all of these changes recently I've been running into issues with the cloud tests that was working previously. Troubleshooting this by temporarily taking this out. 