### PR TITLE
due to redhat bug do not upgrade dnf if -3 available

### DIFF
--- a/update_dnf.sls
+++ b/update_dnf.sls
@@ -2,8 +2,13 @@
 {% set fedora22 = True if fedora and grains['osrelease'] == '22' else False %}
 {% set fedora23 = True if fedora and grains['osrelease'] == '23' else False %}
 {% set fedora24 = True if fedora and grains['osrelease'] == '24' else False %}
+{% set dnf_version = salt['pkg.latest_version']('dnf') %}
 
-{% if fedora23 or fedora24 %}
+{% if dnf_version == '1.1.10-3.fc24' %}
+not_updating:
+  cmd.run:
+    - name: echo "not updatig dnf due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1415441"
+{% elif fedora23 or fedora24 %}
 update_dnf:
   cmd.run:
     - name: 'dnf upgrade -y dnf'


### PR DESCRIPTION
Due to this bug: bugzilla.redhat.com/show_bug.cgi?id=1415441 the states on fedora 24 are failing periodically due to the state that upgrades dnf. This will not upgrade dnf and hence allow us to continue the test suite. This will also allow us to upgrade dnf once the new dnf package with the fix becomes available as well