### PR TITLE
Make sure ca-certificates is installed on Cent/RHEL

### DIFF
--- a/curl.sls
+++ b/curl.sls
@@ -10,17 +10,25 @@
   {% set install_method = 'pkg.installed' %}
 {% endif %}
 
-{%- if grains['os'] == 'openSUSE' %}
+{%- if grains['os_family'] == 'RedHat' or grains['os'] == 'openSUSE' %}
 include:
-  - ca-certificates-mozilla
+  {%- if grains['os'] == 'openSUSE' %}
+   - ca-certificates-mozilla
+  {%- elif grains['os_family'] == 'RedHat' %}
+   - python.ca-certificates
+  {%- endif %}
 {%- endif %}
 
 curl:
   {{ install_method }}:
     - name: {{ curl }}
-    {%- if grains['os'] == 'openSUSE' %}
+    {%- if grains['os_family'] == 'RedHat' or grains['os'] == 'openSUSE' %}
     - require:
+      {%- if grains['os'] == 'openSUSE' %}
       - pkg: ca-certificates-mozilla
+      {%- elif grains['os_family'] == 'RedHat' %}
+      - pkg: ca-certificates
+      {%- endif %}
     {%- endif %}
 
 

--- a/git/init.sls
+++ b/git/init.sls
@@ -6,7 +6,16 @@
   {% set git = 'git' %}
 {% endif %}
 
+{%- if grains['os_family'] == 'RedHat' %}
+include:
+   - python.ca-certificates
+{%- endif %}
+
 git:
   pkg.installed:
     - name: {{ git }}
     - refresh: True  # Ensure that pacman runs the first time with -Syu
+    {%- if grains['os_family'] %}
+    - require:
+      - pkg: ca-certificates
+    {%- endif %}


### PR DESCRIPTION
In an attempt to handle:
```
12:14:10 02:07:33,322 [salt.pillar.git_pillar                     :506 ][ERROR   ] Unable to fetch the latest changes from remote https://github.com/saltstack/pillar2.git: Cmd('git') failed due to: exit code(128)
12:14:10   cmdline: git fetch
12:14:10   stderr: 'fatal: unable to access 'https://github.com/saltstack/pillar2.git/': Peer's Certificate has expired.'

12:14:11 02:07:33,496 [salt.pillar.git_pillar                     :506 ][ERROR   ] Unable to fetch the latest changes from remote https://github.com/saltstack/pillar1.git: Cmd('git') failed due to: exit code(128)
12:14:11   cmdline: git fetch
12:14:11   stderr: 'fatal: unable to access 'https://github.com/saltstack/pillar1.git/': Peer's Certificate has expired.'

12:15:08 02:08:34,062 [salt.pillar.git_pillar                     :506 ][ERROR   ] Unable to fetch the latest changes from remote https://github.com/saltstack/pillar1.git: Cmd('git') failed due to: exit code(128)
12:15:08   cmdline: git fetch
12:15:08   stderr: 'fatal: unable to access 'https://github.com/saltstack/pillar1.git/': Peer's Certificate has expired.'
12:15:08 02:08:34,256 [salt.pillar.git_pillar                     :506 ][ERROR   ] Unable to fetch the latest changes from remote https://github.com/saltstack/pillar2.git: Cmd('git') failed due to: exit code(128)
12:15:08   cmdline: git fetch
12:15:08   stderr: 'fatal: unable to access 'https://github.com/saltstack/pillar2.git/': Peer's Certificate has expired.'

12:15:08 02:08:34,449 [salt.pillar.git_pillar                     :506 ][ERROR   ] Unable to fetch the latest changes from remote https://github.com/saltstack/pillar1.git: Cmd('git') failed due to: exit code(128)
12:15:08   cmdline: git fetch
12:15:08   stderr: 'fatal: unable to access 'https://github.com/saltstack/pillar1.git/': Peer's Certificate has expired.'
```