### PR TITLE
Limit the unittest-xml-reporting install version for CentOS 5/6

### DIFF
--- a/python/unittest-xml-reporting.sls
+++ b/python/unittest-xml-reporting.sls
@@ -5,7 +5,9 @@ include:
 
 unittest-xml-reporting:
   pip.installed:
-    {#= - name: git+https://github.com/s0undt3ch/unittest-xml-reporting.git#egg=unittest-xml-reporting #}
+    {%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'][0] <= '6' %}
+    - name: git+https://github.com/s0undt3ch/unittest-xml-reporting.git#egg=unittest-xml-reporting
+    {%- endif %}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
unittest-xml-reporting no longer supports Python 2.6 past the 1.14.0 release. We need to restore installing the stable version of the package for distros that are still running Python 2.6.