### PR TITLE
Update README to include information on how to run salt-call directly against this state tree

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,3 +2,19 @@ salt-jenkins
 ============
 
 Salt states used to run jenkins tests
+
+Locally Running States
+----------------------
+
+You can clone this repository, and, as long as you already have salt installed, you can
+run this state tree directly(instead of using gitfs).
+
+For example:
+
+.. code-block: sh
+
+    salt-call state.sls git.salt pillar="{py3: true, test_transport: zeromq, with_coverage: true}"
+
+
+This is possible due to the fact that included in this state tree repository there's a `Saltfile` and a `minion`
+configuration files which sets everything up in order to run salt-call locally against this state tree.

--- a/_modules/pip.py
+++ b/_modules/pip.py
@@ -98,6 +98,9 @@ def install(*args, **kwargs):  # pylint: disable=function-redefined
     if 'PYTHONIOENCODING' not in env_vars:
         log.debug('Explicitly setting environment variable "PYTHONIOENCODING=utf-8')
         env_vars['PYTHONIOENCODING'] = 'utf-8'
+    if 'LC_ALL' not in env_vars:
+        log.debug('Explicitly setting environment variable "LC_ALL=en_US.UTF-8"')
+        env_vars['LC_ALL'] = 'en_US.UTF-8'
     kwargs['env_vars'] = env_vars
     return pip_install(*args, **kwargs)
 

--- a/_modules/pip.py
+++ b/_modules/pip.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import
 import os
 import types
+import logging
 
 # Import salt libs
 from salt.utils import namespaced_function
@@ -33,6 +34,9 @@ for name in dir(salt.modules.pip):
         if attr in globals():
             continue
         globals()[name] = namespaced_function(attr, globals())
+
+
+log = logging.getLogger(__name__)
 
 
 __func_alias__ = {
@@ -92,6 +96,7 @@ def install(*args, **kwargs):  # pylint: disable=function-redefined
     # still fail under Python 3, let's explicitly set PYTHONIOENCODING environment variable
     # to utf-8
     if 'PYTHONIOENCODING' not in env_vars:
+        log.debug('Explicitly setting environment variable "PYTHONIOENCODING=utf-8')
         env_vars['PYTHONIOENCODING'] = 'utf-8'
     kwargs['env_vars'] = env_vars
     return pip_install(*args, **kwargs)

--- a/_modules/pip.py
+++ b/_modules/pip.py
@@ -84,6 +84,16 @@ _get_pip_bin = get_pip_bin
 def install(*args, **kwargs):  # pylint: disable=function-redefined
     pip_binary = _get_pip_bin(kwargs.get('bin_env'))
     kwargs['bin_env'] = pip_binary
+    env_vars = kwargs.pop('env_vars', None)
+    if not env_vars:
+        env_vars = {}
+    # Some packages are not really competent at handling systems with poorly setup locales
+    # Since this state tree properly configures the locale and yet, some packages, moto,
+    # still fail under Python 3, let's explicitly set PYTHONIOENCODING environment variable
+    # to utf-8
+    if 'PYTHONIOENCODING' not in env_vars:
+        env_vars['PYTHONIOENCODING'] = 'utf-8'
+    kwargs['env_vars'] = env_vars
     return pip_install(*args, **kwargs)
 
 

--- a/python/headers.sls
+++ b/python/headers.sls
@@ -28,9 +28,15 @@
   {%- else %}
     {%- set python_dev = 'python-devel' %}
   {%- endif %}
+{%- elif grains['os_family'] == 'Debian' %}
+  {%- if pillar.get('py3', False) %}
+    {%- set python_dev = 'python3-dev' %}
+  {%- else %}
+    {%- set python_dev = 'python-dev' %}
+  {%- endif %}
 {%- else %}
   {%- if pillar.get('py3', False) %}
-    {%- set python_dev = 'python34-dev' %}
+    {%- set python_dev = 'python3-dev' %}
   {%- else %}
     {%- set python_dev = 'python-dev' %}
   {%- endif %}

--- a/python/moto.sls
+++ b/python/moto.sls
@@ -10,11 +10,6 @@ moto:
     {%- endif %}
     - index_url: https://pypi-jenkins.saltstack.com/jenkins/develop
     - extra_index_url: https://pypi.python.org/simple
-    {%- if pillar.get('py3', False) %}
-    - env_vars:
-        LC_ALL: en_US.UTF-8
-        PYTHONIOENCODING: utf-8
-    {%- endif %}
 {%- if grains['os'] not in ('Windows') %}
     - require:
       - cmd: pip-install


### PR DESCRIPTION
Handle problematic packages encoding issues directly on the overridden pip module.