### PR TITLE
Add docker to support new docker integration tests

### DIFF
--- a/docker.sls
+++ b/docker.sls
@@ -1,0 +1,10 @@
+{%- if grains['os'] == 'CentOS' and grains['osrelease']|int == 7 %}
+docker:
+  pkg.installed:
+    - pkgs:
+      - docker
+      - busybox
+  service.running:
+    - require:
+      - pkg: docker
+{%- endif %}

--- a/docker.sls
+++ b/docker.sls
@@ -1,10 +1,14 @@
 {%- if grains['os'] == 'CentOS' and grains['osrelease']|int == 7 %}
+/usr/bin/busybox:
+  file.managed:
+    - source: http://repo.saltstack.com/dev/testing/redhat/7/x86_64/archive/busybox/1.26.2/busybox-x86_64
+    - source_hash: 79b3c42078019db853f499852dac831afda935acf9df4c748c3bab914f1cf298
+
 docker:
   pkg.installed:
-    - pkgs:
-      - docker
-      - busybox
+    - name: docker
   service.running:
     - require:
+      - file: /usr/bin/busybox
       - pkg: docker
 {%- endif %}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -29,6 +29,7 @@
 {%- endif %}
 
 include:
+  - docker
   - locale
   {# on OSX, these utils are available from the system rather than the pkg manager (brew) #}
   {%- if grains.get('os', '') != 'MacOS' %}


### PR DESCRIPTION
**NOTE: This should not be merged until @dmurphy18 has built busybox and added it to our EL7 repo. We need busybox to generate a minimal image to be used in the ingration tests (so that we don't have to dep on a Docker registry to run them), but it is not available in EPEL7.**

This pull request provides the needed tools to allow for docker integration test to run in Jenkins.