### PR TITLE
Gate pytest installation for Ubuntu 12.

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -148,11 +148,13 @@ include:
   - openssl
   {%- endif %}
   - python.salttesting
+  {%- if grains['os'] != 'Ubuntu' or (grains['os'] == 'Ubuntu' and not grains['osrelease'].startswith('12.')) %}
   - python.pytest
   - python.pytest-tempdir
   - python.pytest-catchlog
   - python.pytest-helpers-namespace
   - python.pytest-salt
+  {%- endif %}
 
 /testing:
   file.directory


### PR DESCRIPTION
The pytest deps don't allow the salt-master test daemon to fully start, which then prevents the salt-minion test daemons to spin since they can't connect to the salt-master. We need to gate the pytest installations when running on Ubuntu 12 so we can get the tests running again on the 2016.3 branch.

These missing dependencies will cause problems when attempting to run the tests on Salt's develop branch on Ubuntu 12. However, since Ubuntu 12 is EOL soon, it should be OK if we can't run tests on the develop branch for Ubuntu 12.

Fixes #284 and refs #277

ping @cachedout and @s0undt3ch 