### PR TITLE
Add back docker-py for all platforms

### DIFF
--- a/docker.sls
+++ b/docker.sls
@@ -1,6 +1,3 @@
-include:
-  - python.pip
-
 /usr/bin/busybox:
   file.managed:
     - source: http://repo.saltstack.com/dev/testing/redhat/7/x86_64/archive/busybox/1.26.2/busybox-x86_64
@@ -14,11 +11,3 @@ docker:
     - require:
       - file: /usr/bin/busybox
       - pkg: docker
-  pip.installed:
-    {%- if salt['config.get']('virtualenv_path', None)  %}
-    - bin_env: {{ salt['config.get']('virtualenv_path') }}
-    {%- endif %}
-    - index_url: https://pypi-jenkins.saltstack.com/jenkins/develop
-    - extra_index_url: https://pypi.python.org/simple
-    - require:
-      - cmd: pip-install

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -29,7 +29,10 @@
 {%- endif %}
 
 include:
+  # All VMs get docker-py so they can run unit tests
+  - python.docker
   {%- if grains['os'] == 'CentOS' and grains['osmajorrelease']|int == 7 %}
+  # Docker integration tests only on CentOS 7 (for now)
   - docker
   {%- endif %}
   - locale
@@ -169,6 +172,9 @@ clone-salt-repo:
     - rev: {{ pillar.get('test_git_commit', 'develop') }}
     - target: /testing
     - require:
+      # All VMs get docker-py so they can run unit tests
+      - pip: docker
+      # Docker integration tests only on CentOS 7 (for now)
       {%- if grains['os'] == 'CentOS' and grains['osmajorrelease']|int == 7 %}
       - service: docker
       - pkg: docker

--- a/python/docker.sls
+++ b/python/docker.sls
@@ -1,0 +1,14 @@
+include:
+  - python.pip
+
+# Can't use "docker" as ID declaration, it's being used in salt://docker.sls
+docker_py:
+  pip.installed:
+    - name: docker
+    {%- if salt['config.get']('virtualenv_path', None)  %}
+    - bin_env: {{ salt['config.get']('virtualenv_path') }}
+    {%- endif %}
+    - index_url: https://pypi-jenkins.saltstack.com/jenkins/develop
+    - extra_index_url: https://pypi.python.org/simple
+    - require:
+      - cmd: pip-install


### PR DESCRIPTION
This was removed in 41a8c16, but without it unit tests can't be run on
non-CentOS platforms.