### PR TITLE
Add pygit2 installation for integration tests

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -89,6 +89,7 @@ include:
   - python.cherrypy
   - python.etcd
   - python.gitpython
+  - python.pygit2
   {%- if not ( pillar.get('py3', False) and grains['os'] == 'Windows' ) %}
   - python.supervisor
   {%- endif %}

--- a/python/pygit2.sls
+++ b/python/pygit2.sls
@@ -1,0 +1,14 @@
+{%- set os = grains['os'] %}
+{%- set os_family = grains['os_family'] %}
+{%- set osrelease = grains['osrelease'] %}
+{%- set osmajorrelease = grains.get('osmajorrelease', '')|int %}
+
+{%- if os_family in ('Arch', 'RedHat') or os == 'Ubuntu' and osmajorrelease >= 16 %}
+install_pygit2:
+  pkg.installed:
+    {%- if os_family == 'Arch' %}
+    - name: python2-pygit2
+    {%- else %}
+    - name: python-pygit2
+    {%- endif %}
+{% endif %}

--- a/python/pygit2.sls
+++ b/python/pygit2.sls
@@ -11,4 +11,5 @@ install_pygit2:
     {%- else %}
     - name: python-pygit2
     {%- endif %}
+    - aggregate: True
 {% endif %}


### PR DESCRIPTION
This uses system packages because pygit2 needs a compatible libgit2, as
well as other dependencies, making it more of a pain to simply pip
install. So, we lean on the distro packagers to ensure that pygit2 is
available.