### PR TITLE
[Suse Py3] Update python3-devel package name

### DIFF
--- a/python/headers.sls
+++ b/python/headers.sls
@@ -24,7 +24,7 @@
   {%- endif %}
 {%- elif grains['os_family'] == 'Suse' %}
   {%- if pillar.get('py3', False) %}
-    {%- set python_dev = 'python34-devel' %}
+    {%- set python_dev = 'python3-devel' %}
   {%- else %}
     {%- set python_dev = 'python-devel' %}
   {%- endif %}


### PR DESCRIPTION
The package we need is named "python3-devel" and not "python34-devel"

@s0undt3ch can you review and merge when you get a moment?