### PR TITLE
[Fedora Py3] Update python3-devel package name

### DIFF
--- a/python/headers.sls
+++ b/python/headers.sls
@@ -1,7 +1,7 @@
 {%- if grains['os_family'] == 'RedHat' %}
   {%- if grains['os'] in ('Fedora', 'Amazon') %}
     {%- if pillar.get('py3', False) %}
-      {%- set python_dev = 'python34-devel' %}
+      {%- set python_dev = 'python3-devel' %}
     {%- else %}
       {%- set python_dev = 'python-devel' %}
     {%- endif %}


### PR DESCRIPTION
The package we need is named "python3-devel" and not "python34-devel"