### PR TITLE
[Fedora] Use correct package names for pygit2 package

### DIFF
--- a/python/pygit2.sls
+++ b/python/pygit2.sls
@@ -3,13 +3,21 @@
 {%- set osrelease = grains['osrelease'] %}
 {%- set osmajorrelease = grains.get('osmajorrelease', '')|int %}
 
+{%- if os_family == 'Arch' %}
+    {%- set pygit2_pkg = 'python2-pygit2' %}
+{%- elif os == 'Fedora' %}
+    {%- if pillar.get('py3', False) %}
+        {%- set pygit2_pkg = 'python3-pygit2' %}
+    {%- else %}
+        {%- set pygit2_pkg = 'python2-pygit2' %}
+    {% endif %}
+{%- else %}
+    {%- set pygit2_pkg = 'python-pygit2' %}
+{% endif %}
+
 {%- if os_family in ('Arch', 'RedHat') or os == 'Ubuntu' and osmajorrelease >= 16 %}
 install_pygit2:
   pkg.installed:
-    {%- if os_family == 'Arch' %}
-    - name: python2-pygit2
-    {%- else %}
-    - name: python-pygit2
-    {%- endif %}
+    - name: {{ pygit2_pkg  }}
     - aggregate: True
 {% endif %}


### PR DESCRIPTION
This fixes the state failures for the Fedora test runs.