### PR TITLE
Remove aggressive checking for Fedora version

### DIFF
--- a/dnf-plugins.sls
+++ b/dnf-plugins.sls
@@ -1,3 +1,0 @@
-dnf-plugins:
-  cmd.run:
-    - name: dnf upgrade --assumeyes dnf-plugins-core

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -134,13 +134,8 @@ include:
   {%- if grains['os'] == 'Fedora' or (grains['os'] == 'CentOS' and grains['osmajorrelease'] == '5') %}
   - gpg
   {%- endif %}
-  {%- if grains['os'] == 'Fedora' and grains['osrelease'] == '22' or '23' %}
+  {%- if grains['os'] == 'Fedora' %}
   - versionlock
-  {%- endif %}
-  {%- if grains['os'] == 'Fedora' and grains['osrelease'] == '22' %}
-  - dnf-plugins
-  {%- endif %}
-  {%- if grains['os'] == 'Fedora' and grains['osrelease'] == '23' %}
   - redhat-rpm-config
   {%- endif %}
   {%- if grains['os'] != 'MacOS' %}
@@ -289,7 +284,7 @@ clone-salt-repo:
       - pkg: dmidecode
       {%- endif %}
       {%- endif %}
-      {%- if grains['os'] == 'Fedora' and grains['osrelease'] == '23' %}
+      {%- if grains['os'] == 'Fedora' %}
       - pkg: redhat-rpm-config
       {%- endif %}
       {%- if grains['os'] in ('MacOS', 'Debian') %}

--- a/npm.sls
+++ b/npm.sls
@@ -1,9 +1,6 @@
 {% set suse = True if grains['os_family'] == 'Suse' else False %}
 {% set freebsd = True if grains['os'] == 'FreeBSD' else False %}
-{% set fedora = True if grains['os'] == 'Fedora' else False %}
 {% set macos = True if grains['os'] == 'MacOS' else False %}
-
-{% set fedora24 = True if fedora and grains['osrelease'] == '24' else False %}
 
 # Suse does not package npm separately
 {% if suse %}

--- a/python/mysqldb.sls
+++ b/python/mysqldb.sls
@@ -1,7 +1,11 @@
 {% if grains['os_family'] == 'Arch' %}
   {% set mysqldb = 'mysql-python' %}
 {% elif grains['os_family'] == 'RedHat' %}
-  {% set mysqldb = 'MySQL-python' %}
+  {% if grains['os'] == 'Fedora' %}
+    {% set mysqldb = 'python2-mysql' %}
+  {% else %}
+    {% set mysqldb = 'MySQL-python' %}
+  {% endif %}
 {% elif grains['os_family'] == 'Suse' %}
   {% set mysqldb = 'python-MySQL-python' %}
 {% elif grains['os_family'] == 'FreeBSD' %}
@@ -15,10 +19,6 @@
   {% set mysqldb = 'pymysqldb' %}
 {% else %}
   {% set install_method = 'pkg.installed' %}
-{% endif %}
-
-{% if grains['os'] == 'Fedora' and grains['osrelease'] in ['23', '24'] %}
-  {% set mysqldb = 'python2-mysql' %}
 {% endif %}
 
 mysqldb:

--- a/python/psutil.sls
+++ b/python/psutil.sls
@@ -1,13 +1,8 @@
-{%- set fedora = True if grains['os'] == 'Fedora' else False %}
-
 {%- if grains['os'] not in ('Windows') %}
 include:
   {%- if grains['os_family'] not in ('FreeBSD', 'Gentoo') %}
   - gcc
   {%- endif %}
-  {%- if fedora %}
-  - redhat-rpm-config
-  {% endif %}
   - python.pip
 {%- if grains['os_family'] not in ('Arch', 'Solaris', 'FreeBSD', 'Gentoo', 'MacOS') %}
 {#- These distributions don't ship the develop headers separately #}
@@ -26,9 +21,6 @@ psutil:
       {#- These distributions don't ship the develop headers separately #}
       - pkg: python-dev
       {%- endif %}
-      {%- if fedora %}
-      - pkg: redhat-rpm-config
-      {% endif %}
       {%- if grains['os_family'] not in ('FreeBSD', 'Gentoo') %}
         {#- FreeBSD always ships with gcc #}
       - pkg: gcc

--- a/python/psutil.sls
+++ b/python/psutil.sls
@@ -1,19 +1,11 @@
 {%- set fedora = True if grains['os'] == 'Fedora' else False %}
-{%- set fedora23 = True if fedora and grains['osrelease'] == '23' else False %}
-{%- set fedora24 = True if fedora and grains['osrelease'] == '24' else False %}
-
-{%- if fedora23 %}
-  {%- set python_dev = 'python-devel' %}
-{%- else %}
-  {%- set python_dev = 'python-dev' %}
-{%- endif %}
 
 {%- if grains['os'] not in ('Windows') %}
 include:
   {%- if grains['os_family'] not in ('FreeBSD', 'Gentoo') %}
   - gcc
   {%- endif %}
-  {%- if fedora23 or fedora24 %}
+  {%- if fedora %}
   - redhat-rpm-config
   {% endif %}
   - python.pip
@@ -32,9 +24,9 @@ psutil:
     - require:
       {%- if grains['os_family'] not in ('Arch', 'Solaris', 'FreeBSD', 'Gentoo', 'MacOS') %}
       {#- These distributions don't ship the develop headers separately #}
-      - pkg: {{ python_dev }}
+      - pkg: python-dev
       {%- endif %}
-      {%- if fedora23 or fedora24 %}
+      {%- if fedora %}
       - pkg: redhat-rpm-config
       {% endif %}
       {%- if grains['os_family'] not in ('FreeBSD', 'Gentoo') %}

--- a/python/setproctitle.sls
+++ b/python/setproctitle.sls
@@ -1,4 +1,3 @@
-{% set fedora = True if grains['os'] == 'Fedora' else False %}
 {% if grains['os'] not in ('Windows') %}
 include:
   - python.pip
@@ -14,7 +13,4 @@ setproctitle:
 {% if grains['os'] not in ('Windows') %}
     - require:
       - cmd: pip-install
-      {%- if fedora %}
-      - pkg: redhat-rpm-config
-      {% endif %}
 {% endif %}

--- a/python/setproctitle.sls
+++ b/python/setproctitle.sls
@@ -1,5 +1,4 @@
 {% set fedora = True if grains['os'] == 'Fedora' else False %}
-{% set fedora24 = True if fedora and grains['osrelease'] == '24' else False %}
 {% if grains['os'] not in ('Windows') %}
 include:
   - python.pip
@@ -15,7 +14,7 @@ setproctitle:
 {% if grains['os'] not in ('Windows') %}
     - require:
       - cmd: pip-install
-      {%- if fedora24 %}
+      {%- if fedora %}
       - pkg: redhat-rpm-config
       {% endif %}
 {% endif %}

--- a/python/timelib.sls
+++ b/python/timelib.sls
@@ -1,14 +1,9 @@
-{% set fedora = True if grains['os'] == 'Fedora' else False %}
-
 {% if grains['os'] not in ('Windows') %}
 include:
   {%- if grains['os_family'] not in ('FreeBSD', 'Gentoo') %}
   - gcc
   {%- endif %}
   - python.pip
-  {%- if fedora %}
-  - redhat-rpm-config
-  {% endif %}
   {%- if grains['os_family'] not in ('Arch', 'Solaris', 'FreeBSD', 'Gentoo', 'MacOS') %}
   {#- These distributions don't ship the develop headers separately #}
   - python.headers
@@ -29,9 +24,6 @@ timelib:
       {#- These distributions don't ship the develop headers separately #}
       - pkg: python-dev
       {%- endif %}
-      {% if fedora %}
-      - pkg: redhat-rpm-config
-      {% endif %}
       {%- if grains['os_family'] not in ('FreeBSD', 'Gentoo') %}
         {#- FreeBSD always ships with gcc #}
       - pkg: gcc

--- a/python/timelib.sls
+++ b/python/timelib.sls
@@ -1,12 +1,4 @@
 {% set fedora = True if grains['os'] == 'Fedora' else False %}
-{% set fedora23 = True if fedora and grains['osrelease'] == '23' else False %}
-{% set fedora24 = True if fedora and grains['osrelease'] == '24' else False %}
-
-{% if fedora23 %}
-  {%- set python_dev = 'python-devel' %}
-{% else %}
-  {%- set python_dev = 'python-dev' %}
-{% endif %}
 
 {% if grains['os'] not in ('Windows') %}
 include:
@@ -14,7 +6,7 @@ include:
   - gcc
   {%- endif %}
   - python.pip
-  {%- if fedora23 or fedora24 %}
+  {%- if fedora %}
   - redhat-rpm-config
   {% endif %}
   {%- if grains['os_family'] not in ('Arch', 'Solaris', 'FreeBSD', 'Gentoo', 'MacOS') %}
@@ -35,9 +27,9 @@ timelib:
     - require:
       {%- if grains['os_family'] not in ('Arch', 'Solaris', 'FreeBSD', 'Gentoo', 'MacOS') %}
       {#- These distributions don't ship the develop headers separately #}
-      - pkg: {{ python_dev }}
+      - pkg: python-dev
       {%- endif %}
-      {% if fedora23 or fedora24 %}
+      {% if fedora %}
       - pkg: redhat-rpm-config
       {% endif %}
       {%- if grains['os_family'] not in ('FreeBSD', 'Gentoo') %}

--- a/update_dnf.sls
+++ b/update_dnf.sls
@@ -1,14 +1,10 @@
-{% set fedora = True if grains['os'] == 'Fedora' else False %}
-{% set fedora22 = True if fedora and grains['osrelease'] == '22' else False %}
-{% set fedora23 = True if fedora and grains['osrelease'] == '23' else False %}
-{% set fedora24 = True if fedora and grains['osrelease'] == '24' else False %}
 {% set dnf_version = salt['pkg.latest_version']('dnf') %}
 
 {% if dnf_version == '1.1.10-3.fc24' %}
 not_updating:
   cmd.run:
-    - name: echo "not updatig dnf due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1415441"
-{% elif fedora23 or fedora24 %}
+    - name: echo "not updating dnf due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1415441"
+{% else %}
 update_dnf:
   cmd.run:
     - name: 'dnf upgrade -y dnf'

--- a/versionlock.sls
+++ b/versionlock.sls
@@ -1,22 +1,10 @@
-{% set fedora = True if grains['os'] == 'Fedora' else False %}
-{% set fedora22 = True if fedora and grains['osrelease'] == '22' else False %}
-{% set fedora23 = True if fedora and grains['osrelease'] == '23' else False %}
-{% set fedora24 = True if fedora and grains['osrelease'] == '24' else False %}
-
-{% if fedora23 or fedora24 %}
+{% if salt['grains.get']('os', '') == 'Fedora' %}
 include:
   - update_dnf
-{% endif %}
 
-{% if fedora %}
 versionlock:
   cmd.run:
-    {% if fedora22 %}
-    - name: "dnf install -y 'dnf-command(versionlock)'"
-    {% elif fedora23 or fedora24 %}
     - name: "dnf install -y python-dnf-plugins-extras-versionlock python3-dnf-plugins-extras-versionlock"
     - require:
       - cmd: update_dnf
-    {% endif %}
-
 {% endif %}


### PR DESCRIPTION
Fedora 22 and 23 have reached EOL and we're not testing against those versions anymore. We can remove the checks for those versions.

We are, however, testing Fedora 25 now. Many of the checks for installing Fedora packages were looking specifically for Fedora 22, 23, or 24, but not leaving room for newer versions. Now that the transition from yum to dnf has settled down, let's just look for "Fedora" in all of these states instead of specific versions of Fedora.

This should also fix the installation failures seen against running these states for Fedora 25.

Fixes #306 

Running this PR against a Fedora 25 box now gives the following successful run:
```
# salt-call --local state.sls git.salt
<snipped>
Summary for local
-------------
Succeeded: 66 (changed=5)
Failed:     0
-------------
Total states run:     66
Total run time:   90.114 s
```

Additional changes will likely be necessary in the `nitrogen` branch once these changes are merged-forward for PY3 set up. 