### PR TITLE
Always execute pip install states on Fedora

### DIFF
--- a/python/pip.sls
+++ b/python/pip.sls
@@ -109,7 +109,9 @@ pip2-install:
     - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && python2 get-pip.py -U pip
     - cwd: /
     - reload_modules: True
+    {%- if os != 'Fedora' %}
     - onlyif: '[ "$(which pip2 2>/dev/null)" = "" ]'
+    {%- endif %}
     - require:
       - {{ install_method }}: curl
     {%- if on_redhat_5 %}


### PR DESCRIPTION
These states were limited to running based on the output of the `onlyif` command. But on Fedora, there is a weird bug where the pip3 files are removed from `/usr/bin/pip*`. We can't rely on the `onlyif` clauses in this case and should always run these two states when running the `git.salt` states with `pillar="{py3: true}".

Fixes #311

Related to #305