### PR TITLE
Pin version of moto to 0.4.31

### DIFF
--- a/python/moto.sls
+++ b/python/moto.sls
@@ -5,6 +5,7 @@ include:
 
 moto:
   pip.installed:
+    - name: moto == 0.4.31
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
The new version, 1.0.0, causes nearly all of our boto unit tests to fail.