### PR TITLE
Back-port #344 to 2016.3

### DIFF
--- a/python/moto.sls
+++ b/python/moto.sls
@@ -5,6 +5,7 @@ include:
 
 moto:
   pip.installed:
+    - name: moto == 0.4.31
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Back-port #344 to 2016.3

We need the moto version to be pinned in the 2016.3 branch, too.