### PR TITLE
Do not run locale state on MacOS

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -47,7 +47,7 @@ include:
   - docker
   - python.zookeeper
   {%- endif %}
-  {%- if grains['os'] != 'Windows' %}
+  {%- if os_grain not in ('Windows','MacOS') %}
   - locale
   {%- endif %}
   {# On OSX these utils are available from the system rather than the pkg manager (brew) #}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -47,7 +47,7 @@ include:
   - docker
   - python.zookeeper
   {%- endif %}
-  {%- if os_grain not in ('Windows','MacOS') %}
+  {%- if grains['os'] not in ('Windows','MacOS') %}
   - locale
   {%- endif %}
   {# On OSX these utils are available from the system rather than the pkg manager (brew) #}


### PR DESCRIPTION
local.system is not currently supported on MacOS so removing this state from the salt-jenkins run on mac.