### PR TITLE
need pyyaml greater than 3.12 for tests to pass on MacOS

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -182,6 +182,9 @@ include:
   {%- if grains['os_family'] in ('Arch', 'RedHat', 'Debian') %}
   - nginx
   {%- endif %}
+  {%- if grains['os'] == 'MacOS' %}
+  - python.pyyaml
+  {%- endif %}
 
 {{ testing_dir }}:
   file.directory

--- a/python/pyyaml.sls
+++ b/python/pyyaml.sls
@@ -4,6 +4,7 @@ include:
 
 PyYAML:
   pip.installed:
+    - name: PyYAML >= 3.12
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Fixes #385
Fixes #393
Fixes #394