### PR TITLE
Pin version of paramiko pip install on Debian and newer Ubuntu

### DIFF
--- a/python/junos-eznc.sls
+++ b/python/junos-eznc.sls
@@ -1,5 +1,5 @@
 {% set include_paramiko = False %}
-{% if grains['os'] == 'Debian' or (grains['os'] == 'Ubuntu' and grains['osmajorrelease'] >= 16) %}
+{% if grains['os'] in ['Debian', 'Ubuntu'] %}
   {% set include_paramiko = True %}
 {% endif %}
 

--- a/python/junos-eznc.sls
+++ b/python/junos-eznc.sls
@@ -1,5 +1,13 @@
+{% set include_paramiko = False %}
+{% if grains['os'] == 'Debian' or (grains['os'] == 'Ubuntu' and grains['osmajorrelease'] >= 16) %}
+  {% set include_paramiko = True %}
+{% endif %}
+
 include:
   - python.pip
+  {%- if include_paramiko %}
+  - python.paramiko
+  {%- endif %}
 
 {% if grains['os'] in ['Ubuntu', 'Debian'] %}
 pyez dependencies:
@@ -35,3 +43,6 @@ junos-eznc:
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install
+      {%- if include_paramiko %}
+      - pip: paramiko
+      {%- endif %}

--- a/python/paramiko.sls
+++ b/python/paramiko.sls
@@ -1,0 +1,16 @@
+include:
+  - python.pip
+
+# Newer versions of paramiko (2.2.0) require a minimum version of the
+# PyNaCl lib of 1.0.1, which doesn't install correctly on some distros.
+# This is pinned at 2.1.2 until the installation issues are resolved.
+paramiko:
+  pip.installed:
+    - name: paramiko == 2.1.2
+    {%- if salt['config.get']('virtualenv_path', None)  %}
+    - bin_env: {{ salt['config.get']('virtualenv_path') }}
+    {%- endif %}
+    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - extra_index_url: https://pypi.python.org/simple
+    - require:
+      - cmd: pip-install


### PR DESCRIPTION
Fixes #420

Newer versions of paramiko (2.2.0) require a minimum version of the PyNaCl lib of 1.0.1, which doesn't install correctly on some distros. This is pinned at 2.1.2 until the installation issues are resolved.