### PR TITLE
set locale to UTF-8 for mac tests

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -47,7 +47,7 @@ include:
   - docker
   - python.zookeeper
   {%- endif %}
-  {%- if grains['os'] not in ('Windows','MacOS') %}
+  {%- if grains['os'] not in ('Windows') %}
   - locale
   {%- endif %}
   {# On OSX these utils are available from the system rather than the pkg manager (brew) #}

--- a/locale.sls
+++ b/locale.sls
@@ -4,6 +4,16 @@
 # This will cause integration.shell.matcher.MatchTest.test_salt_documentation_arguments_not_assumed
 # to fail if not set correctly.
 
+{%- if grains['os'] in ('MacOS') %}
+mac_locale:
+  file.blockreplace:
+    - name: /etc/profile
+    - marker_start: #------ start locale zone ------
+    - marker_end: #------ endlocale zone ------
+    - content: |
+        export LANG=en_US.UTF-8
+{%- else %}
+
 {% set suse = True if grains['os_family'] == 'Suse' else False %}
 {% if suse %}
 suse_local:
@@ -20,3 +30,5 @@ default_locale:
     - name: en_US.UTF-8
     - require:
       - locale: us_locale
+
+{%- endif %}


### PR DESCRIPTION
I also double checked, the master branch is being used for all mac tests, and not the nitrogen branch.