### PR TITLE
Add npm workaround for mac

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -364,3 +364,15 @@ install-salt-pytest-pip-deps:
     - requirements: {{ testing_dir }}/requirements/pytest.txt
     - onlyif: '[ -f {{ testing_dir }}/requirements/pytest.txt ]'
 {%- endif %}
+
+{# npm v5 workaround for issue #41770 #}
+{%- if grains['os'] == 'MacOS' %}
+downgrade_node:
+  cmd.run:
+    - name: 'brew switch node 7.0.0'
+    - runas: jenkins
+
+downgrade_npm:
+  npm.installed:
+    - name: npm@3.10.8
+{%- endif %}


### PR DESCRIPTION
Currently there are issues with npm version 5 and compatibility with salt. This is causing the test: `integration.states.npm.NpmStateTest.test_npm_cache_clean` to fail on MacOS with:

```
Traceback (most recent call last):
  File "/opt/salt/lib/python2.7/site-packages/salttesting/helpers.py", line 70, in wrap
    return caller(cls)
  File "/testing/tests/integration/states/npm.py", line 59, in test_npm_cache_clean
    self.assertSaltTrueReturn(ret)
  File "/testing/tests/integration/__init__.py", line 2162, in assertSaltTrueReturn
    **(next(six.itervalues(ret)))
AssertionError: False is not True. Salt Comment:
Error looking up cached packages: npm ERR! Usage: npm cache add <tarball file>
npm ERR! npm cache add <folder>
npm ERR! npm cache add <tarball url>
npm ERR! npm cache add <git url>
npm ERR! npm cache add <name>@<version>
npm ERR! npm cache clean
npm ERR! npm cache verify
```

Because they removed the ability to list the cache. This is a workaround until https://github.com/saltstack/salt/issues/41770 is resolved. 