### PR TITLE
pin node on MacOS

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -375,4 +375,9 @@ downgrade_node:
 downgrade_npm:
   npm.installed:
     - name: npm@3.10.8
+
+pin_npm:
+  cmd.run:
+    - name: 'brew pin node'
+    - runas: jenkins
 {%- endif %}


### PR DESCRIPTION
keep node from updating when the mac brew tests run installs

Remove this block when until saltstack/salt#41770 is resolved

@Ch3LL This should fix our problems with the workaround for now.