### PR TITLE
accept LANG variable over ssh for archlinux

### DIFF
--- a/locale.sls
+++ b/locale.sls
@@ -11,6 +11,18 @@ suse_local:
     - name: glibc-locale
 {% endif %}
 
+{% set arch = True if grains['os_family'] == 'Arch' else False %}
+{% if arch %}
+accept_LANG_sshd:
+  file.append:
+    - name: /etc/ssh/sshd_config
+    - text: AcceptEnv LANG
+  service.running:
+    - name: sshd
+    - listen:
+      - file: accept_LANG_sshd
+{% endif %}
+
 us_locale:
   locale.present:
     - name: en_US.UTF-8


### PR DESCRIPTION
This will allow the locale to be set on arch

By default, Arch does not accept any environment variables, but our centos jenkins slave is sending the LANG variable.  This will set the LANG variable and thus the locale on the arch test box.