### PR TITLE
Fix syntax error from #443

### DIFF
--- a/lsb_release.sls
+++ b/lsb_release.sls
@@ -1,4 +1,4 @@
 {%- if grains['os_family'] == 'Arch' %}
 lsb-release:
   pkg.installed
-{% endif %-}
+{%- endif %}


### PR DESCRIPTION
There is a small syntax error in the new lsb_release.sls file, which causes the following error:

```
local:
    Data failed to compile:
----------
    Rendering SLS 'base:lsb_release' failed: Jinja syntax error: expected token 'end of statement block', got '%'; line 4

---
{%- if grains['os_family'] == 'Arch' %}
lsb-release:
  pkg.installed
{% endif %-}    <======================
---
```
This change fixes the error.

Refs #443.