### PR TITLE
Fix name of pkg require for lsb-release in git/salt.sls

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -331,7 +331,7 @@ clone-salt-repo:
       - pkg: nginx
       {%- endif %}
       {%- if os_family == 'Arch' %}
-      - pkg: lsb_release
+      - pkg: lsb-release
       {%- endif %}
 
 {%- if test_git_url != default_test_git_url %}


### PR DESCRIPTION
The name of the sls file is ``lsb_release``, by the state id is ``pkg: lsb-release``.

Refs #443 and #445