### PR TITLE
Update the version of the coverage package for Arch Py3 builds

### DIFF
--- a/python/coverage.sls
+++ b/python/coverage.sls
@@ -1,4 +1,10 @@
-{% set new_coverage = pillar.get('new_coverage', False) %}
+{% set coverage_version = 'coverage==3.7.1' %}
+
+{% if pillar.get('new_coverage', False) %}
+  {% set coverage_version = 'coverage' %}
+{% elif pillar.get('py3', False) and grains['os'] == 'Arch' %}
+  {% set coverage_version = 'coverage==4.4.1' %}
+{% endif %}
 
 {% if grains['os'] not in ('Windows',) %}
 include:
@@ -7,11 +13,7 @@ include:
 
 coverage:
   pip.installed:
-    {%- if new_coverage %}
-    - name: 'coverage'
-    {%- else %}
-    - name: 'coverage==3.7.1'
-    {%- endif %}
+    - name: {{ coverage_version }}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
The change in https://github.com/saltstack/salt/pull/41865 exposed an issue where the Arch running the Python 3 tests would stacktrace at the end of the test build in Jenkins because the coverage library was out of date/incompatible. This PR changes the version of the coverage package to a known stable version.