### PR TITLE
Set moto version for Py3 and Py2

### DIFF
--- a/python/moto.sls
+++ b/python/moto.sls
@@ -3,9 +3,15 @@ include:
   - python.pip
 {%- endif %}
 
+{%- if pillar.get('py3', False) %}
+  {%- set moto_version = 'moto' %}
+{%- else %}
+  {%- set moto_version = 'moto==0.4.31' %}
+{%- endif %}
+
 moto:
   pip.installed:
-    - name: moto == 0.4.31
+    - name: {{ moto }}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/moto.sls
+++ b/python/moto.sls
@@ -11,7 +11,7 @@ include:
 
 moto:
   pip.installed:
-    - name: {{ moto }}
+    - name: {{ moto_version }}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Moto is now Python 3 compatible starting with versions 1.x. We need to keep the version the same for Python 2 for now, but Py3 tests need a newer version.