### PR TITLE
make sure osmajorrelease is an integer

### DIFF
--- a/versionlock.sls
+++ b/versionlock.sls
@@ -1,4 +1,4 @@
-{% if salt['grains.get']('os', '') == 'Fedora' and grains['osmajorrelease'] < 26 %}
+{% if salt['grains.get']('os', '') == 'Fedora' and grains['osmajorrelease']|int < 26 %}
 include:
   - update_dnf
 

--- a/versionlock.sls
+++ b/versionlock.sls
@@ -1,10 +1,14 @@
-{% if salt['grains.get']('os', '') == 'Fedora' and grains['osmajorrelease']|int < 26 %}
+{% if salt['grains.get']('os', '') == 'Fedora' %}
 include:
   - update_dnf
 
 versionlock:
   cmd.run:
+    {%- if salt.grains.get('osmajorrelease')|int < 26 %}
     - name: "dnf install -y python-dnf-plugins-extras-versionlock python3-dnf-plugins-extras-versionlock"
+    {%- elif salt.grains.get('osmajorrelease')|int >= 26 %}
+    - name: "dnf install -y python2-dnf-plugins-extras-versionlock python3-dnf-plugins-extras-versionlock"
+    {%- endif %}
     - require:
       - cmd: update_dnf
 {% endif %}


### PR DESCRIPTION
The version of salt that we use to bootstrap Fedora 24 has
osmajorrelease as a string.