### PR TITLE
Adding changes to 2017.7 for pypi URL

### DIFF
--- a/_states/pip2_state.py
+++ b/_states/pip2_state.py
@@ -86,7 +86,7 @@ def __virtual__():
 def installed(name, **kwargs):
     index_url = kwargs.pop('index_url', None)
     if index_url is None:
-        index_url = 'https://nexus.c7.saltstack.net/repository/salt-proxy/simple'
+        index_url = 'https://pypi.c7.saltstack.net/simple'
     extra_index_url = kwargs.pop('extra_index_url', None)
     if extra_index_url is None:
         extra_index_url = 'https://pypi.python.org/simple'

--- a/_states/pip3_state.py
+++ b/_states/pip3_state.py
@@ -86,7 +86,7 @@ def __virtual__():
 def installed(name, **kwargs):
     index_url = kwargs.pop('index_url', None)
     if index_url is None:
-        index_url = 'https://nexus.c7.saltstack.net/repository/salt-proxy/simple'
+        index_url = 'https://pypi.c7.saltstack.net/simple'
     extra_index_url = kwargs.pop('extra_index_url', None)
     if extra_index_url is None:
         extra_index_url = 'https://pypi.python.org/simple'

--- a/_states/pip_state.py
+++ b/_states/pip_state.py
@@ -44,7 +44,7 @@ def __virtual__():
 def installed(name, **kwargs):
     index_url = kwargs.pop('index_url', None)
     if index_url is None:
-        index_url = 'https://nexus.c7.saltstack.net/repository/salt-proxy/simple'
+        index_url = 'https://pypi.c7.saltstack.net/simple'
     extra_index_url = kwargs.pop('extra_index_url', None)
     if extra_index_url is None:
         extra_index_url = 'https://pypi.python.org/simple'

--- a/python/argparse.sls
+++ b/python/argparse.sls
@@ -6,7 +6,7 @@ argparse:
     {%- if salt['config.get']('virtualenv_path', None) %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/boto.sls
+++ b/python/boto.sls
@@ -12,7 +12,7 @@ boto:
     {%- if salt['config.get']('pip_target', None)  %}
     - target: {{ salt['config.get']('pip_target') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:
@@ -28,7 +28,7 @@ boto3:
     {%- if salt['config.get']('pip_target', None)  %}
     - target: {{ salt['config.get']('pip_target') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/certifi.sls
+++ b/python/certifi.sls
@@ -6,7 +6,7 @@ certifi:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - upgrade: True
     - require:

--- a/python/cherrypy.sls
+++ b/python/cherrypy.sls
@@ -13,7 +13,7 @@ cherrypy:
     {%- if salt['config.get']('pip_target', None)  %}
     - target: {{ salt['config.get']('pip_target') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/coverage.sls
+++ b/python/coverage.sls
@@ -17,7 +17,7 @@ coverage:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/dns.sls
+++ b/python/dns.sls
@@ -9,7 +9,7 @@ dnspython:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/docker.sls
+++ b/python/docker.sls
@@ -8,7 +8,7 @@ docker_py:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/etcd.sls
+++ b/python/etcd.sls
@@ -9,7 +9,7 @@ python-etcd:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/futures.sls
+++ b/python/futures.sls
@@ -8,7 +8,7 @@ futures:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/gitpython.sls
+++ b/python/gitpython.sls
@@ -15,7 +15,7 @@ gitpython:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/gnupg.sls
+++ b/python/gnupg.sls
@@ -14,7 +14,7 @@ gnupg:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/hgtools.sls
+++ b/python/hgtools.sls
@@ -7,7 +7,7 @@ hgtools:
   {%- if salt['config.get']('virtualenv_path', None)  %}
   - bin_env: {{ salt['config.get']('virtualenv_path') }}
   {%- endif %}
-  - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+  - index_url: https://pypi.c7.saltstack.net/simple
   - extra_index_url: https://pypi.python.org/simple
   - require:
     - cmd: pip-install

--- a/python/ioflo.sls
+++ b/python/ioflo.sls
@@ -8,7 +8,7 @@ ioflo:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/jinja2.sls
+++ b/python/jinja2.sls
@@ -8,7 +8,7 @@ jinja2:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/jsonschema.sls
+++ b/python/jsonschema.sls
@@ -8,7 +8,7 @@ jsonschema:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/keyring.sls
+++ b/python/keyring.sls
@@ -9,7 +9,7 @@ keyring:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - upgrade: True
 {% if grains['os'] not in ('Windows',) %}

--- a/python/libcloud.sls
+++ b/python/libcloud.sls
@@ -9,7 +9,7 @@ apache-libcloud:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/libnacl.sls
+++ b/python/libnacl.sls
@@ -9,7 +9,7 @@ libnacl:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/m2crypto.sls
+++ b/python/m2crypto.sls
@@ -8,7 +8,7 @@ m2crypto:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/mock.sls
+++ b/python/mock.sls
@@ -9,7 +9,7 @@ mock:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/moto.sls
+++ b/python/moto.sls
@@ -15,7 +15,7 @@ moto:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {%- if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/msgpack.sls
+++ b/python/msgpack.sls
@@ -10,7 +10,7 @@ msgpack-python:
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
     - name: msgpack-python >= 0.4.2
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/nose.sls
+++ b/python/nose.sls
@@ -6,7 +6,7 @@ nose:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/paste.sls
+++ b/python/paste.sls
@@ -6,7 +6,7 @@ paste:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/psutil.sls
+++ b/python/psutil.sls
@@ -11,7 +11,7 @@ include:
 psutil:
   pip.installed:
     - upgrade: True
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       {%- if grains['os_family'] not in ('Arch', 'Solaris', 'FreeBSD', 'Gentoo', 'MacOS', 'Windows') %}

--- a/python/pycrypto.sls
+++ b/python/pycrypto.sls
@@ -10,7 +10,7 @@ pycrypto:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/pyinotify.sls
+++ b/python/pyinotify.sls
@@ -8,7 +8,7 @@ pyinotify:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/pytest-catchlog.sls
+++ b/python/pytest-catchlog.sls
@@ -9,7 +9,7 @@ pytest-catchlog:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/pytest-helpers-namespace.sls
+++ b/python/pytest-helpers-namespace.sls
@@ -8,7 +8,7 @@ pytest-helpers-namespace:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/pytest-salt.sls
+++ b/python/pytest-salt.sls
@@ -9,7 +9,7 @@ pytest-salt:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/pytest-tempdir.sls
+++ b/python/pytest-tempdir.sls
@@ -8,7 +8,7 @@ pytest-tempdir:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/pytest.sls
+++ b/python/pytest.sls
@@ -8,7 +8,7 @@ pytest:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/pyvmomi.sls
+++ b/python/pyvmomi.sls
@@ -11,7 +11,7 @@ pyvmomi:
     {%- if salt['config.get']('pip_target', None)  %}
     - target: {{ salt['config.get']('pip_target') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/pyyaml.sls
+++ b/python/pyyaml.sls
@@ -8,7 +8,7 @@ PyYAML:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/pyzmq.sls
+++ b/python/pyzmq.sls
@@ -7,7 +7,7 @@ pyzmq:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - global-options:
       - fetch_libzmq

--- a/python/raet.sls
+++ b/python/raet.sls
@@ -7,7 +7,7 @@ raet:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/requests.sls
+++ b/python/requests.sls
@@ -8,7 +8,7 @@ requests:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/rfc3987.sls
+++ b/python/rfc3987.sls
@@ -8,7 +8,7 @@ rfc3987:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/salttesting.sls
+++ b/python/salttesting.sls
@@ -11,7 +11,7 @@ SaltTesting:
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
     - upgrade: true
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/setproctitle.sls
+++ b/python/setproctitle.sls
@@ -8,7 +8,7 @@ setproctitle:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/six.sls
+++ b/python/six.sls
@@ -12,7 +12,7 @@ six:
     {%- if salt['config.get']('pip_target', None)  %}
     - target: {{ salt['config.get']('pip_target') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/strict_rfc3339.sls
+++ b/python/strict_rfc3339.sls
@@ -8,7 +8,7 @@ strict_rfc3339:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/supervisor.sls
+++ b/python/supervisor.sls
@@ -6,7 +6,7 @@ supervisor:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/timelib.sls
+++ b/python/timelib.sls
@@ -17,7 +17,7 @@ timelib:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       {%- if grains['os_family'] not in ('Arch', 'Solaris', 'FreeBSD', 'Gentoo', 'MacOS') %}

--- a/python/tornado.sls
+++ b/python/tornado.sls
@@ -11,7 +11,7 @@ tornado:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/unittest-xml-reporting.sls
+++ b/python/unittest-xml-reporting.sls
@@ -11,7 +11,7 @@ unittest-xml-reporting:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] not in ('Windows',) %}
     - require:

--- a/python/unittest2.sls
+++ b/python/unittest2.sls
@@ -6,7 +6,7 @@ unittest2:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/virtualenv.sls
+++ b/python/virtualenv.sls
@@ -13,7 +13,7 @@ include:
 virtualenv:
   pip.installed:
     - name: virtualenv{{ virtualenv_pin }}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
 {% if grains['os'] != 'Windows' %}
     - require:

--- a/python/webtest.sls
+++ b/python/webtest.sls
@@ -6,7 +6,7 @@ webtest:
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://pypi.c7.saltstack.net/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install


### PR DESCRIPTION
Cherry picked changes to 2017.7 from 2016.11.
Updates the pypi URL's to new ones that are more secure.