### PR TITLE
Install CherryPy < 11.0.0 for Python 2.6

### DIFF
--- a/python/cherrypy.sls
+++ b/python/cherrypy.sls
@@ -7,6 +7,10 @@ include:
 
 cherrypy:
   pip.installed:
+    {% if on_py26 %}
+    {# CherryPy 11.0.0 dropped support for Python 2.6 -#}
+    - name: "cherrypy < 11.0.0"
+    {% endif %}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
CherryPy 11 dropped support for 2.6, so installing the newest available
version causes the pip.installed state in the git.salt SLS to fail.