### PR TITLE
Don't peg moto version on Py2 anymore

### DIFF
--- a/python/moto.sls
+++ b/python/moto.sls
@@ -3,15 +3,8 @@ include:
   - python.pip
 {%- endif %}
 
-{%- if pillar.get('py3', False) %}
-  {%- set moto_version = 'moto' %}
-{%- else %}
-  {%- set moto_version = 'moto==0.4.31' %}
-{%- endif %}
-
 moto:
   pip.installed:
-    - name: {{ moto_version }}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
The changes in https://github.com/saltstack/salt/pull/42883 require moto >= 1.0.0 for both Py2 and Py3 tests.

**Warning**: This will cause failures for many boto tests until https://github.com/saltstack/salt/pull/42883 is merged.

https://github.com/saltstack/salt-jenkins/issues/478