### PR TITLE
Back-port #486 to 2016.11

### DIFF
--- a/python/moto.sls
+++ b/python/moto.sls
@@ -5,7 +5,6 @@ include:
 
 moto:
   pip.installed:
-    - name: moto == 0.4.31
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Back-port #486 to 2016.11

We need this change on 2016.11 after https://github.com/saltstack/salt/pull/42959 is merged.