### PR TITLE
Fix missing name parameters on Windows

### DIFF
--- a/python/cherrypy.sls
+++ b/python/cherrypy.sls
@@ -5,7 +5,7 @@ include:
 
 {% set on_py26 = True if grains.get('pythonexecutable', '').endswith('2.6') else False %}
 
-install_cherry_py:
+cherry_py:
   pip.installed:
     - name: cherrypy
     {%- if salt['config.get']('virtualenv_path', None)  %}

--- a/python/cherrypy.sls
+++ b/python/cherrypy.sls
@@ -5,8 +5,9 @@ include:
 
 {% set on_py26 = True if grains.get('pythonexecutable', '').endswith('2.6') else False %}
 
-cherrypy:
+install_cherry_py:
   pip.installed:
+    - name: cherrypy
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/cherrypy.sls
+++ b/python/cherrypy.sls
@@ -5,7 +5,7 @@ include:
 
 {% set on_py26 = True if grains.get('pythonexecutable', '').endswith('2.6') else False %}
 
-cherry_py:
+cherrypy:
   pip.installed:
     - name: cherrypy
     {%- if salt['config.get']('virtualenv_path', None)  %}

--- a/python/futures.sls
+++ b/python/futures.sls
@@ -5,6 +5,7 @@ include:
 
 futures:
   pip.installed:
+    - name: futures
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/ioflo.sls
+++ b/python/ioflo.sls
@@ -3,7 +3,7 @@ include:
   - python.pip
 {% endif %}
 
-install_ioflo:
+ioflo:
   pip.installed:
     - name: ioflo
     {%- if salt['config.get']('virtualenv_path', None)  %}

--- a/python/ioflo.sls
+++ b/python/ioflo.sls
@@ -3,8 +3,9 @@ include:
   - python.pip
 {% endif %}
 
-ioflo:
+install_ioflo:
   pip.installed:
+    - name: ioflo
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/jsonschema.sls
+++ b/python/jsonschema.sls
@@ -3,8 +3,9 @@ include:
   - python.pip
 {% endif %}
 
-jsonschema:
+install_jsonschema:
   pip.installed:
+    - name: jsonschema
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/jsonschema.sls
+++ b/python/jsonschema.sls
@@ -3,7 +3,7 @@ include:
   - python.pip
 {% endif %}
 
-install_jsonschema:
+jsonschema:
   pip.installed:
     - name: jsonschema
     {%- if salt['config.get']('virtualenv_path', None)  %}

--- a/python/moto.sls
+++ b/python/moto.sls
@@ -3,7 +3,7 @@ include:
   - python.pip
 {%- endif %}
 
-install_moto:
+moto:
   pip.installed:
     - name: moto
     {%- if salt['config.get']('virtualenv_path', None)  %}

--- a/python/moto.sls
+++ b/python/moto.sls
@@ -3,8 +3,9 @@ include:
   - python.pip
 {%- endif %}
 
-moto:
+install_moto:
   pip.installed:
+    - name: moto
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/pytest-helpers-namespace.sls
+++ b/python/pytest-helpers-namespace.sls
@@ -5,6 +5,7 @@ include:
 
 pytest-helpers-namespace:
   pip.installed:
+    - name: pytest-helpers-namespace
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/pytest-tempdir.sls
+++ b/python/pytest-tempdir.sls
@@ -5,6 +5,7 @@ include:
 
 pytest-tempdir:
   pip.installed:
+    - name: pytest-tempdir
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/pytest.sls
+++ b/python/pytest.sls
@@ -3,7 +3,7 @@ include:
   - python.pip
 {% endif %}
 
-install_pytest:
+pytest:
   pip.installed:
     - name: pytest
     {%- if salt['config.get']('virtualenv_path', None)  %}

--- a/python/pytest.sls
+++ b/python/pytest.sls
@@ -3,8 +3,9 @@ include:
   - python.pip
 {% endif %}
 
-pytest:
+install_pytest:
   pip.installed:
+    - name: pytest
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/pyvmomi.sls
+++ b/python/pyvmomi.sls
@@ -5,6 +5,7 @@ include:
 
 pyvmomi:
   pip.installed:
+    - name: pyvmomi
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/requests.sls
+++ b/python/requests.sls
@@ -5,6 +5,7 @@ include:
 
 requests:
   pip.installed:
+    - name: requests
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/rfc3987.sls
+++ b/python/rfc3987.sls
@@ -5,6 +5,7 @@ include:
 
 rfc3987:
   pip.installed:
+    - name: rfc3987
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/setproctitle.sls
+++ b/python/setproctitle.sls
@@ -3,7 +3,7 @@ include:
   - python.pip
 {% endif %}
 
-install_setproctitle:
+setproctitle:
   pip.installed:
     - name: setproctitle
     {%- if salt['config.get']('virtualenv_path', None)  %}

--- a/python/setproctitle.sls
+++ b/python/setproctitle.sls
@@ -3,8 +3,9 @@ include:
   - python.pip
 {% endif %}
 
-setproctitle:
+install_setproctitle:
   pip.installed:
+    - name: setproctitle
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/strict_rfc3339.sls
+++ b/python/strict_rfc3339.sls
@@ -5,6 +5,7 @@ include:
 
 strict_rfc3339:
   pip.installed:
+    - name: strict_rfc3339
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}

--- a/python/unittest-xml-reporting.sls
+++ b/python/unittest-xml-reporting.sls
@@ -3,7 +3,7 @@ include:
   - python.pip
 {% endif %}
 
-install_unittest-xml-reporting:
+unittest-xml-reporting:
   pip.installed:
     - name: unittest-xml-reporting
     {%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease']|int <= 6 %}

--- a/python/unittest-xml-reporting.sls
+++ b/python/unittest-xml-reporting.sls
@@ -3,8 +3,9 @@ include:
   - python.pip
 {% endif %}
 
-unittest-xml-reporting:
+install_unittest-xml-reporting:
   pip.installed:
+    - name: unittest-xml-reporting
     {%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease']|int <= 6 %}
     - name: git+https://github.com/s0undt3ch/unittest-xml-reporting.git#egg=unittest-xml-reporting
     {%- endif %}


### PR DESCRIPTION
The test suite isn't starting in Windows with the following error for many files:
```
ID 'cherrypy' in SLS 'python.cherrypy' contains a short declaration (pip.installed) with a trailing colon. When not passing any arguments to a state, the colon must be omitted.
```
Here's the sls:
```
cherrypy:
  pip.installed:
    {%- if salt['config.get']('virtualenv_path', None)  %}
    - bin_env: {{ salt['config.get']('virtualenv_path') }}
    {%- endif %}
    {%- if salt['config.get']('pip_target', None)  %}
    - target: {{ salt['config.get']('pip_target') }}
    {%- endif %}
{% if grains['os'] not in ('Windows',) %}
    - require:
      - cmd: pip-install
{% endif %}
```
In Windows the rendered SLS looks something like this:
```
cherrypy:
  pip.installed:
```
This PR adds the `- name:` parameter to the affected SLS files.

@rallytime ^^^^