### PR TITLE
Moving the pytest-catchlog.sls to pull from pypi.

### DIFF
--- a/python/pytest-catchlog.sls
+++ b/python/pytest-catchlog.sls
@@ -5,7 +5,7 @@ include:
 
 pytest-catchlog:
   pip.installed:
-    - name: git+https://github.com/eisensheng/pytest-catchlog.git@develop#egg=Pytest-catchlog
+    - name: pytest-catchlog
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
This should get the package from pypi instead of git on develop. It is only breaking on Python3 on Fedora 26 at the moment.