### PR TITLE
Moving the pytest-salt.sls to pull from pypi.

### DIFF
--- a/python/pytest-salt.sls
+++ b/python/pytest-salt.sls
@@ -5,7 +5,7 @@ include:
 
 pytest-salt:
   pip.installed:
-    - name: git+https://github.com/saltstack/pytest-salt.git@master#egg=pytest-salt
+    - name: pytest-salt
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
This should get the package from pypi instead of git on develop. It is only breaking on Python3 on Fedora 26 at the moment.