### PR TITLE
Pin moto version on CentOS 6

### DIFF
--- a/python/moto.sls
+++ b/python/moto.sls
@@ -3,8 +3,15 @@ include:
   - python.pip
 {%- endif %}
 
+{%- if grains['os'] == 'CentOS' and grains['osmajorrelease'] == '6' %}
+  {%- set moto_version = 'moto==1.0.1' %}
+{%- else %}
+  {%- set moto_version = 'moto' %}
+{%- endif %}
+
 moto:
   pip.installed:
+    - name: {{ moto_version }}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Newer packages of moto do not support Python 2.6 very well and cause issues in the test suite.

Pinning the version of moto allows the boto tests to run on Py2.6 and don't hang the test suite.