### PR TITLE
looks like sssd is not always installed by default on centos 7.4

### DIFF
--- a/sssd.sls
+++ b/sssd.sls
@@ -1,2 +1,3 @@
 sssd:
-  service.dead
+  service.dead:
+    - onlyif: systemctl is-active sssd


### PR DESCRIPTION
https://jenkins.saltstack.com/job/branch_tests/job/2017.7/job/salt-linode-cent7/304/consoleFull