### PR TITLE
update pyopenssl for mac

### DIFF
--- a/pyopenssl.sls
+++ b/pyopenssl.sls
@@ -4,7 +4,7 @@
     {%- else %}
       {% set pyopenssl = 'python2-pyOpenSSL' %}
     {%- endif %}
-{% elif grains['os_family'] in ('RedHat','MacOS', 'Windows') %}
+{% elif grains['os_family'] in ('RedHat', 'MacOS', 'Windows') %}
   {% set pyopenssl = 'pyOpenSSL' %}
 {% elif grains['os_family'] == 'Suse' %}
   {% set pyopenssl = 'python-pyOpenSSL' %}
@@ -31,4 +31,8 @@ pyopenssl:
     - name: {{ pyopenssl }}
     {%- if install_method == 'pkg.installed' %}
     - aggregate: True
+    {%- endif %}
+    {%- if grains['os_family'] in ('MacOS',) %}
+    {# MacOS needs to upgrade to the newest since we install the newest OpenSSL from Brew #}
+    - upgrade: True
     {%- endif %}


### PR DESCRIPTION
We need to make sure that we have this newer version of pyopenssl for
the mac, which has the newest version of openssl from brew

Fixes https://github.com/saltstack/salt-jenkins/pull/510

Basically what happens on mac is we manage the packages in the build images with brew.  So we always have the newest version of OpenSSL.  The newest version of OpenSSL is not compatible with versions of pyopenssl before 16.2.0.

@twangboy if we package pyopenssl in the mac packages, we may need to upgrade it to at least 16.2.0

Thanks,
Daniel