### PR TITLE
Add verifier to automatically run salt tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,7 +18,7 @@ provisioner:
   salt_install: bootstrap
   salt_version: latest
   salt_bootstrap_url: https://bootstrap.saltstack.com
-  salt_bootstrap_options: -X stable <%= (ENV['TRAVIS_BRANCH'] != 'master' ? ENV['TRAVIS_BRANCH'] : '') %>
+  salt_bootstrap_options: -X stable <%= ENV['TRAVIS_BRANCH'] != 'master' ? ENV['TRAVIS_BRANCH'] : '' %>
   log_level: info
   is_file_root: true
   require_chef: false
@@ -43,7 +43,7 @@ platforms:
       image: fedora:latest
       run_command: /usr/lib/systemd/systemd
     provisioner:
-      salt_bootstrap_options: -X git <%= (ENV['TRAVIS_BRANCH'] != 'master' ? ENV['TRAVIS_BRANCH'] : '') %> >/dev/null
+      salt_bootstrap_options: -X git <%= ENV['TRAVIS_BRANCH'] != 'master' ? ENV['TRAVIS_BRANCH'] : '' %> >/dev/null
   - name: centos-7
     driver_config:
       run_command: /usr/lib/systemd/systemd
@@ -53,7 +53,7 @@ platforms:
       provision_command:
         - yum install -y upstart
     provisioner:
-      salt_bootstrap_options: -P -y -x python2.7 -X git <%= (ENV['TRAVIS_BRANCH'] != 'master' ? ENV['TRAVIS_BRANCH'] : '') %> >/dev/null
+      salt_bootstrap_options: -P -y -x python2.7 -X git <%= ENV['TRAVIS_BRANCH'] != 'master' ? ENV['TRAVIS_BRANCH'] : '' %> >/dev/null
   - name: ubuntu-rolling
     driver_config:
       image: ubuntu:rolling
@@ -87,7 +87,7 @@ platforms:
         - systemctl enable sshd
         - echo 'L /run/docker.sock - - - - /docker.sock' > /etc/tmpfiles.d/docker.conf
     provisioner:
-      salt_bootstrap_options: -X git <%= (ENV['TRAVIS_BRANCH'] != 'master' ? ENV['TRAVIS_BRANCH'] : '') %> >/dev/null
+      salt_bootstrap_options: -X git <%= ENV['TRAVIS_BRANCH'] != 'master' ? ENV['TRAVIS_BRANCH'] : '' %> >/dev/null
   - name: opensuse
     driver_config:
       run_command: /usr/lib/systemd/systemd
@@ -95,7 +95,7 @@ platforms:
         - systemctl enable sshd.service
         - echo 'L /run/docker.sock - - - - /docker.sock' > /etc/tmpfiles.d/docker.conf
     provisioner:
-      salt_bootstrap_options: -X git <%= (ENV['TRAVIS_BRANCH'] != 'master' ? ENV['TRAVIS_BRANCH'] : '') %> >/dev/null
+      salt_bootstrap_options: -X git <%= ENV['TRAVIS_BRANCH'] != 'master' ? ENV['TRAVIS_BRANCH'] : '' %> >/dev/null
 <% if @vagrant != false %>
   - name: windows-2012r2
     driver:
@@ -144,7 +144,7 @@ suites:
               - jenkins
         jenkins.sls:
           test_git_url: git://github.com/saltstack/salt.git
-          test_git_commit: <%= (ENV['TRAVIS_BRANCH'] == 'master' ? 'develop' : ENV['TRAVIS_BRANCH']) %>
+          test_git_commit: <%= ENV['TRAVIS_BRANCH'] == 'master' ? 'develop' : ENV['TRAVIS_BRANCH'] %>
   - name: py3
     excludes:
       - centos-6
@@ -156,7 +156,7 @@ suites:
               - jenkins
         jenkins.sls:
           test_git_url: git://github.com/saltstack/salt.git
-          test_git_commit: <%= (ENV['TRAVIS_BRANCH'] == 'master' ? 'develop' : ENV['TRAVIS_BRANCH']) %>
+          test_git_commit: <%= ENV['TRAVIS_BRANCH'] == 'master' ? 'develop' : ENV['TRAVIS_BRANCH'] %>
           py3: true
 verifier:
   name: shell

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,6 +36,7 @@ provisioner:
     base:
       "*":
         - git.salt
+        - kitchen
 platforms:
   - name: fedora
     driver_config:
@@ -157,3 +158,7 @@ suites:
           test_git_url: git://github.com/saltstack/salt.git
           test_git_commit: <%= (ENV['TRAVIS_BRANCH'] == 'master' ? 'develop' : ENV['TRAVIS_BRANCH']) %>
           py3: true
+verifier:
+  name: shell
+  remote_exec: true
+  command: '$(kitchen) /testing/tests/runtests.py -v --output-columns=80 --run-destructive<%= ENV["TEST"] ? " -n #{ENV["TEST"]}" : "" %>'

--- a/kitchen/init.sls
+++ b/kitchen/init.sls
@@ -1,0 +1,4 @@
+/usr/local/bin/kitchen:
+  file.managed:
+    - source: salt://kitchen/kitchen.py
+    - mode: 755

--- a/kitchen/kitchen.py
+++ b/kitchen/kitchen.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import salt.client
+import salt.config
+
+__opts__ = salt.config.minion_config('/tmp/kitchen/etc/salt/minion')
+__opts__['file_client'] = 'local'
+caller = salt.client.Caller(mopts=__opts__)
+if caller.cmd('config.get', 'py3', False):
+    print('python3')
+elif caller.cmd('config.get', 'os_family') == 'RedHat' and int(caller.cmd('config.get', 'osmajorrelease')) == 6:
+    print('python2.7')
+else:
+    print('python2')


### PR DESCRIPTION
This is not run in the travis-ci tests, but is useful for when you want to run a specific test automatically.

Defaults to running the full test suite, but can run one set of tests.

```
TEST=integration.states.test_docker_container TRAVIS_BRANCH=2017.7 bundle exec kitchen verify py2-centos-7
```