### PR TITLE
Get virtual_subtype if available: we can't assume it's in grains

### DIFF
--- a/docker.sls
+++ b/docker.sls
@@ -1,3 +1,5 @@
+ {% set on_docker = salt['grains.get']('virtual_subtype', '') in ('Docker',) %}
+
 /usr/bin/busybox:
   file.managed:
     - source: http://repo.saltstack.com/dev/testing/redhat/7/x86_64/archive/busybox/1.26.2/busybox-x86_64
@@ -7,7 +9,7 @@
 docker:
   pkg.installed:
     - aggregate: True
-{%- if grains.virtual_subtype not in ('Docker',) %}
+{%- if on_docker == False %}
   service.running:
     - require:
       - file: /usr/bin/busybox

--- a/extra-swap.sls
+++ b/extra-swap.sls
@@ -1,4 +1,5 @@
 {% set swapfile = '/.salt-runtests.swapfile' %}
+{% set on_docker = salt['grains.get']('virtual_subtype', '') in ('Docker',) %}
 
 create-swap-file:
   {# because everytime a new subprocess.Popen() is instantiated, a copy of the current python
@@ -44,7 +45,7 @@ add-extra-swap:
     - unless: grep -q {{ swapfile }} /proc/swaps
     - require:
       - cmd: create-swap-file
-  {%- if grains.virtual_subtype not in ('Docker',) %}
+  {%- if on_docker == False %}
   mount.swap:
     - name: {{ swapfile }}
     - persist: False

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -3,6 +3,7 @@
 {%- set test_transport = pillar.get('test_transport', 'zeromq') %}
 {%- set os_family = salt['grains.get']('os_family', '') %}
 {%- set os_major_release = salt['grains.get']('osmajorrelease', 0)|int %}
+{% set on_docker = salt['grains.get']('virtual_subtype', '') in ('Docker',) %}
 
 {%- if os_family == 'RedHat' and os_major_release == 5 %}
   {%- set on_redhat_5 = True %}
@@ -198,7 +199,7 @@ clone-salt-repo:
       - pip: docker
       # Docker integration tests only on CentOS 7 (for now)
       {%- if grains['os'] == 'CentOS' and os_major_release == 7 %}
-      {%- if grains.virtual_subtype not in ('Docker',) %}
+      {%- if on_docker == False %}
       - service: docker
       - pkg: docker
       {%- endif %}
@@ -209,7 +210,7 @@ clone-salt-repo:
       {%- if grains['os'] == 'FreeBSD' %}
       - cmd: add-extra-swap
       {%- else %}
-      {%- if grains['os'] != 'Windows' and grains.virtual_subtype not in ('Docker',) %}
+      {%- if grains['os'] != 'Windows' and on_docker == False %}
       - mount: add-extra-swap
       {%- endif %}
       {%- endif %}

--- a/locale.sls
+++ b/locale.sls
@@ -5,11 +5,13 @@
 # to fail if not set correctly.
 
 {% set suse = True if grains['os_family'] == 'Suse' else False %}
+{% set on_docker = salt['grains.get']('virtual_subtype', '') in ('Docker',) %}
+
 {% if suse %}
 suse_local:
   pkg.installed:
     - name: glibc-locale
-{% elif grains.os_family == 'Debian' %}
+{% elif grains.os_family == 'Debian' and on_docker %}
 deb_locale:
   pkg.installed:
     - pkgs:


### PR DESCRIPTION
Running `grains.virtual_subtype` crashes if `virtual_subtype` isn't available. We need to gate this check a little more carefully. I'm running a test on a VM presently, but let's see how the docker tests go as well.