### PR TITLE
Use pip to install pyopenssl instead of pkg managers

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -267,16 +267,12 @@ clone-salt-repo:
       - pip: tornado
       - pip: pyvmomi
       - pip: pycrypto
+      - pip: pyopenssl
       {%- if (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('12.')) or (grains['os'] == 'CentOS' and os_major_release == 5) %}
       - pip: jinja2
       {%- endif %}
       {%- if grains['os'] != 'MacOS' %}
-      {%- if grains['os'] == 'Windows' or (grains['os'] == 'Debian' and grains['osrelease'].startswith('8')) %}
-      - pip: pyopenssl
-      {%- else %}
       - pip: pyinotify
-      - pkg: pyopenssl
-      {%- endif %}
       {%- endif %}
       {%- if grains.get('pythonversion')[:2] < [3, 2] %}
       - pip: futures

--- a/pyopenssl.sls
+++ b/pyopenssl.sls
@@ -1,38 +1,8 @@
-{% if grains['os'] == 'Fedora' and salt.grains.get('osmajorrelease')|int >= 26 %}
-    {%- if pillar.get('py3', False) %}
-      {% set pyopenssl = 'python3-pyOpenSSL' %}
-    {%- else %}
-      {% set pyopenssl = 'python2-pyOpenSSL' %}
-    {%- endif %}
-{% elif grains['os_family'] in ('RedHat', 'MacOS', 'Windows') %}
-  {% set pyopenssl = 'pyOpenSSL' %}
-{% elif grains['os_family'] == 'Suse' %}
-  {% set pyopenssl = 'python-pyOpenSSL' %}
-{% elif grains['os_family'] == 'Debian' %}
-  {% if grains['osrelease'].startswith('8') %}
-    {% set pyopenssl = 'pyOpenSSL==0.13' %}
-  {% else %}
-    {% set pyopenssl = 'python-openssl' %}
-  {% endif %}
-{% elif grains['os'] == 'Arch' %}
-  {% set pyopenssl = 'python2-pyopenssl' %}
-{% elif grains['os'] == 'FreeBSD' %}
-  {% set pyopenssl = 'security/py-openssl' %}
-{% endif %}
-
-{% if grains['os'] in ('MacOS', 'Windows') or (grains['os_family'] == 'Debian' and grains['osrelease'].startswith('8')) %}
-  {% set install_method = 'pip.installed' %}
-{% else %}
-  {% set install_method = 'pkg.installed' %}
+{% if grains['os'] not in ('Windows',) %}
+include:
+  - python.pip
 {% endif %}
 
 pyopenssl:
-  {{ install_method }}:
-    - name: {{ pyopenssl }}
-    {%- if install_method == 'pkg.installed' %}
-    - aggregate: True
-    {%- endif %}
-    {%- if grains['os_family'] in ('MacOS',) %}
-    {# MacOS needs to upgrade to the newest since we install the newest OpenSSL from Brew #}
-    - upgrade: True
-    {%- endif %}
+  pip.installed:
+    - name: pyOpenSSL


### PR DESCRIPTION
The versions of pyopenssl that are installed via package managers can be very out of date. This is particularly true for the Ubuntu and CentOS distros.

The latest version of moto requires a version of pyopenssl >= `0.14`. Ubuntu packages `0.13`. This is causing about 100 boto tests to fail.

Pyopenssl is on version 17.x in pip, so by using pip to install instead of the packaged versions, we can run the boto tests and they pass. We can also catch issues further up the line with a newer pyopenssl package in our test suite.

Fixes #526