### PR TITLE
Update PyOpenSSL pip packages on Ubuntu 16

### DIFF
--- a/pyopenssl.sls
+++ b/pyopenssl.sls
@@ -3,6 +3,12 @@ include:
   - python.pip
 {% endif %}
 
+{% set os_family = salt['grains.get']('os_family', '') %}
+{% set os_major_release = salt['grains.get']('osmajorrelease', 0)|int %}
+
 pyopenssl:
   pip.installed:
     - name: pyOpenSSL
+    {%- if os_family == 'Debian' and os_major_release == 16 %}
+    - upgrade: True
+    {%- endif %}

--- a/pyopenssl.sls
+++ b/pyopenssl.sls
@@ -3,12 +3,7 @@ include:
   - python.pip
 {% endif %}
 
-{% set os_family = salt['grains.get']('os_family', '') %}
-{% set os_major_release = salt['grains.get']('osmajorrelease', 0)|int %}
-
 pyopenssl:
   pip.installed:
     - name: pyOpenSSL
-    {%- if os_family == 'Debian' and os_major_release == 16 %}
     - upgrade: True
-    {%- endif %}


### PR DESCRIPTION
The Ubuntu 16 images already have pyopenssl installed via pip. It is an old version (0.15) that does not allow the test daemons to start.

Upgrading the pyopenssl package to match the other distro tests fixes the issue and makes the Ubuntu 16 test runs consitent with the other distros.

Every distro should be running the current latest PyOpenSSL pip package, which is currently 17.3.0.

Fixes #532