### PR TITLE
Pin cffi version to 1.11.0 when running python 3 tests

### DIFF
--- a/pyopenssl.sls
+++ b/pyopenssl.sls
@@ -1,8 +1,16 @@
 {% if grains['os'] not in ('Windows',) %}
 include:
   - python.pip
+  - python.cffi
 {% endif %}
 
 pyopenssl:
   pip.installed:
     - name: pyOpenSSL
+    {%- if grains['os'] not in ('Windows',) %}
+    - require:
+      - cmd: pip-install
+    {%- if pillar.get('py3', False) %}
+      - pip: cffi
+    {%- endif %}
+    {%- endif %}

--- a/python/cffi.sls
+++ b/python/cffi.sls
@@ -1,0 +1,12 @@
+{% if grains['os'] not in ('Windows',) %}
+include:
+  - python.pip
+{% endif %}
+
+cffi:
+  pip.installed:
+    - name: cffi==1.11.0
+{% if grains['os'] not in ('Windows',) %}
+    - require:
+      - cmd: pip-install
+{% endif %}


### PR DESCRIPTION
When the version of pyopenssl was updated in #529 and we switched to using pip to install pyopenssl, the cffi pip package is also pulled in. The latest version of cffi and pyopenssl is causing problems on the python 3 test runs. Pinning the cffi package to a slightly older package resolves the issue.

Fixes #534 

For the record, here's the stacktraces that happens on 10-30 tests on Python 3 test runs with the newest version of cffi:
```
       Traceback (most recent call last):
         File "/testing/tests/support/mixins.py", line 486, in assertReturnSaltType
           self.assertTrue(isinstance(ret, dict))
         File "/usr/lib/python3.5/unittest/case.py", line 677, in assertTrue
           raise self.failureException(msg)
       AssertionError: False is not true

       During handling of the above exception, another exception occurred:

       Traceback (most recent call last):
         File "/testing/tests/support/mixins.py", line 543, in assertSaltTrueReturn
           for saltret in self.__getWithinSaltReturn(ret, 'result'):
         File "/testing/tests/support/mixins.py", line 516, in __getWithinSaltReturn
           self.assertReturnNonEmptySaltType(ret)
       AssertionError: str is not dict. Salt returned: The minion function caused an exception: AttributeError: cffi library '_constant_time' has no function, constant or global variable named '__loader__'

       During handling of the above exception, another exception occurred:

       Traceback (most recent call last):
         File "/testing/salt/minion.py", line 1466, in _thread_return
           return_data = executor.execute()
         File "/testing/salt/executors/direct_call.py", line 28, in execute
           return self.func(*self.args, **self.kwargs)
         File "/testing/salt/modules/state.py", line 1689, in single
           st_.call(kwargs)}
         File "/testing/salt/state.py", line 1882, in call
           self.check_refresh(low, ret)
         File "/testing/salt/state.py", line 961, in check_refresh
           self.module_refresh()
         File "/testing/salt/state.py", line 917, in module_refresh
           reload_module(site)
         File "/usr/lib/python3.5/importlib/__init__.py", line 166, in reload
           _bootstrap._exec(spec, module)
         File "<frozen importlib._bootstrap>", line 626, in _exec
         File "<frozen importlib._bootstrap_external>", line 665, in exec_module
         File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
         File "/usr/lib/python3.5/site.py", line 580, in <module>
           main()
         File "/usr/lib/python3.5/site.py", line 561, in main
           abs_paths()
         File "/usr/lib/python3.5/site.py", line 107, in abs_paths
           if (getattr(getattr(m, '__loader__', None), '__module__', None) not in
       SystemError: <built-in function getattr> returned a result with an error set


       During handling of the above exception, another exception occurred:

       Traceback (most recent call last):
         File "/testing/tests/support/mixins.py", line 550, in assertSaltTrueReturn
           **(next(six.itervalues(ret)))
         File "/testing/salt/ext/six.py", line 585, in itervalues
           return iter(d.values(**kw))
       AttributeError: 'str' object has no attribute 'values'

       During handling of the above exception, another exception occurred:

       Traceback (most recent call last):
         File "/testing/tests/integration/states/test_file.py", line 887, in test_recurse
           self.assertSaltTrueReturn(ret)
         File "/testing/tests/support/mixins.py", line 556, in assertSaltTrueReturn
           pprint.pformat(ret)
       AssertionError: Failed to get result. Salt Returned:
       ('The minion function caused an exception: AttributeError: cffi library '
        "'_constant_time' has no function, constant or global variable named "
        "'__loader__'\n"
        '\n'
        'During handling of the above exception, another exception occurred:\n'
        '\n'
        'Traceback (most recent call last):\n'
        '  File "/testing/salt/minion.py", line 1466, in _thread_return\n'
        '    return_data = executor.execute()\n'
        '  File "/testing/salt/executors/direct_call.py", line 28, in execute\n'
        '    return self.func(*self.args, **self.kwargs)\n'
        '  File "/testing/salt/modules/state.py", line 1689, in single\n'
        '    st_.call(kwargs)}\n'
        '  File "/testing/salt/state.py", line 1882, in call\n'
        '    self.check_refresh(low, ret)\n'
        '  File "/testing/salt/state.py", line 961, in check_refresh\n'
        '    self.module_refresh()\n'
        '  File "/testing/salt/state.py", line 917, in module_refresh\n'
        '    reload_module(site)\n'
        '  File "/usr/lib/python3.5/importlib/__init__.py", line 166, in reload\n'
        '    _bootstrap._exec(spec, module)\n'
        '  File "<frozen importlib._bootstrap>", line 626, in _exec\n'
        '  File "<frozen importlib._bootstrap_external>", line 665, in exec_module\n'
        '  File "<frozen importlib._bootstrap>", line 222, in '
        '_call_with_frames_removed\n'
        '  File "/usr/lib/python3.5/site.py", line 580, in <module>\n'
        '    main()\n'
        '  File "/usr/lib/python3.5/site.py", line 561, in main\n'
        '    abs_paths()\n'
        '  File "/usr/lib/python3.5/site.py", line 107, in abs_paths\n'
        "    if (getattr(getattr(m, '__loader__', None), '__module__', None) not in\n"
        'SystemError: <built-in function getattr> returned a result with an error '
        'set\n')
```