### PR TITLE
Change the ordering of the pyopenssl and cffi states

### DIFF
--- a/pyopenssl.sls
+++ b/pyopenssl.sls
@@ -12,6 +12,7 @@ pyopenssl:
     - require:
       - cmd: pip-install
     {%- if pillar.get('py3', False) %}
+    - require_in:
       - pip: cffi
     {%- endif %}
     {%- endif %}


### PR DESCRIPTION
The cffi state should run after the pyopenssl state. This is necessary because the "upgrade: True" setting in pyopenssl.sls overrides the cffi==1.11.0 name in the cffi state. The require_in addition swaps the order so the cffi state will ensure the pinned version is installed.

Refs #536, #534, #533, and #532.