### PR TITLE
allow not cloning the repository for kitchen tests

### DIFF
--- a/_states/pip_state.py
+++ b/_states/pip_state.py
@@ -55,4 +55,47 @@ def installed(name, **kwargs):
         index_url=index_url,
         extra_index_url=extra_index_url,
         user=sudo_user or None)
+    kwargs = salt.utils.clean_kwargs(**kwargs)
     return pip_state_installed(name, **kwargs)
+
+def mod_aggregate(low, chunks, running):
+    '''
+    The mod_aggregate function which looks up all packages in the available
+    low chunks and merges them into a single pkgs ref in the present low data
+    '''
+    pkgs = []
+    # What functions should we aggregate?
+    agg_enabled = ['installed',]
+    # The `low` data is just a dict with the state, function (fun) and
+    # arguments passed in from the sls
+    if low.get('fun') not in agg_enabled:
+        return low
+    # Now look into what other things are set to execute
+    for chunk in chunks:
+        # The state runtime uses "tags" to track completed jobs, it may
+        # look familiar with the _|-
+        tag = salt.utils.gen_state_tag(chunk)
+        if tag in running:
+            # Already ran the pkg state, skip aggregation
+            continue
+        if chunk.get('state') == 'pip':
+            if '__agg__' in chunk:
+                continue
+            # Check for the same function
+            if chunk.get('fun') != low.get('fun'):
+                continue
+            # Pull out the pkg names!
+            if 'pkgs' in chunk:
+                pkgs.extend(chunk['pkgs'])
+                chunk['__agg__'] = True
+            elif 'name' in chunk:
+                pkgs.append(chunk['name'])
+                chunk['__agg__'] = True
+    if pkgs:
+        if 'pkgs' in low:
+            low['pkgs'].extend(pkgs)
+        else:
+            low['pkgs'] = pkgs
+    # The low has been modified and needs to be returned to the state
+    # runtime for execution
+    return low

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -11,6 +11,14 @@
   {%- set on_redhat_5 = False %}
 {%- endif %}
 
+{%- if pillar.get('testing_dir') %}
+  {%- set testing_dir = pillar.get('testing_dir') %}
+{%- elif grains['os'] == 'Windows' %}
+  {%- set testing_dir = 'C:\\testing' %}
+{%- else %}
+  {%- set testing_dir = '/testing' %}
+{%- endif %}
+
 {%- if os_family == 'Arch' %}
   {%- set on_arch = True %}
 {%- else %}
@@ -157,9 +165,10 @@ include:
   - python.pytest-salt
   {%- endif %}
 
-/testing:
+{{testing_dir}}:
   file.directory
 
+{%- if pillar.get('clone_repo', True) %}
 clone-salt-repo:
   git.latest:
     - name: {{ test_git_url }}
@@ -308,21 +317,22 @@ fetch-upstream-tags:
     - require:
       - cmd: add-upstream-repo
 {%- endif %}
+{%- endif %}
 
 {%- if pillar.get('py3', False) %}
 {#- Install Salt Dev Dependencies #}
 install-salt-pip-deps:
   pip.installed:
-    - requirements: /testing/requirements/{{ test_transport }}.txt
-    - onlyif: '[ -f /testing/requirements/{{ test_transport }}.txt ]'
+    - requirements: {{testing_dir}}/requirements/{{ test_transport }}.txt
+    - onlyif: '[ -f {{testing_dir}}/requirements/{{ test_transport }}.txt ]'
 
 install-salt-dev-pip-deps:
   pip.installed:
-    - requirements: /testing/requirements/dev_{{ python }}.txt
-    - onlyif: '[ -f /testing/requirements/dev_{{ python }}.txt ]'
+    - requirements: {{testing_dir}}/requirements/dev_{{ python }}.txt
+    - onlyif: '[ -f {{testing_dir}}/requirements/dev_{{ python }}.txt ]'
 
 install-salt-pytest-pip-deps:
   pip.installed:
-    - requirements: /testing/requirements/pytest.txt
-    - onlyif: '[ -f /testing/requirements/pytest.txt ]'
+    - requirements: {{testing_dir}}/requirements/pytest.txt
+    - onlyif: '[ -f {{testing_dir}}/requirements/pytest.txt ]'
 {%- endif %}

--- a/kitchen/init.sls
+++ b/kitchen/init.sls
@@ -1,0 +1,5 @@
+/usr/bin/kitchen:
+  file.managed:
+    - source: salt://kitchen/kitchen.py
+    - template: jinja
+    - mode: 755

--- a/kitchen/kitchen.py
+++ b/kitchen/kitchen.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env {{ 'python3' if salt.pillar.get('py3') else 'python2' }}
+import salt.client
+import salt.config
+
+__opts__ = salt.config.minion_config('/tmp/kitchen/etc/salt/minion')
+__opts__['file_client'] = 'local'
+caller = salt.client.Caller(mopts=__opts__)
+if caller.cmd('config.get', 'py3', False):
+    print('python3')
+elif caller.cmd('config.get', 'os_family') == 'RedHat' and int(caller.cmd('config.get', 'osmajorrelease')) == 6:
+    print('python2.7')
+else:
+    print('python2')


### PR DESCRIPTION
Running tests with kitchen-salt, we will be copying over the jenkins workspace to the testing environment, instead of cloning it down.