### PR TITLE
Make sure that nofile ulimit is not too low

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -191,6 +191,9 @@ include:
   - lsb_release
   {%- endif %}
   - sssd
+  {%- if grains['kernel'] == 'Linux' %}
+  - ulimits
+  {%- endif %}
 
 {{ testing_dir }}:
   file.directory
@@ -337,6 +340,9 @@ clone-salt-repo:
       {%- endif %}
       # disable sssd if running
       - service: sssd
+      {%- if grains['kernel'] == 'Linux' %}
+      - file: ulimits-nofile
+      {%- endif %}
 
 {%- if test_git_url != default_test_git_url %}
 {#- Add Salt Upstream Git Repo #}

--- a/ulimits.sls
+++ b/ulimits.sls
@@ -1,0 +1,7 @@
+{%- if grains['kernel'] == 'Linux' %}
+ulimits-nofile:
+  file.managed:
+    - name: /etc/security/limits.d/83-nofile.conf
+    - mode: 644
+    - contents: 'root - nofile 1048576'
+{%- endif %}


### PR DESCRIPTION
While fs.nr_open is over 1 million, the nofile ulimit defaults to 1024
on the Linode test VMs. This commit increases the nofile ulimit.