### PR TITLE
Disabling swap on OpenSuse for now. Its broken across the test suite …

### DIFF
--- a/extra-swap.sls
+++ b/extra-swap.sls
@@ -1,5 +1,6 @@
 {% set swapfile = '/.salt-runtests.swapfile' %}
 {% set on_docker = salt['grains.get']('virtual_subtype', '') in ('Docker',) %}
+{%- if pillar.get('disable_swap') != True %}
 
 create-swap-file:
   {# because everytime a new subprocess.Popen() is instantiated, a copy of the current python
@@ -53,4 +54,5 @@ add-extra-swap:
       - cmd: make-swap
     - unless: grep -q {{ swapfile }} /proc/swaps
   {%- endif %}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
Disabling swap for OpenSuse for now.

After I will have to add: ` --test-pillar disable_swap True` to the OpenSuse jobs.