### PR TITLE
Moving this to grains instead of pillar.

### DIFF
--- a/extra-swap.sls
+++ b/extra-swap.sls
@@ -1,6 +1,6 @@
 {% set swapfile = '/.salt-runtests.swapfile' %}
 {% set on_docker = salt['grains.get']('virtual_subtype', '') in ('Docker',) %}
-{%- if pillar.get('disable_swap') != True %}
+{%- if salt['grains.get']('oscodename') != 'openSUSE Leap 42.2' %}
 
 create-swap-file:
   {# because everytime a new subprocess.Popen() is instantiated, a copy of the current python

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -192,8 +192,10 @@ clone-salt-repo:
       {%- if grains['os'] == 'FreeBSD' %}
       - cmd: add-extra-swap
       {%- else %}
+      {%- if grains['oscodename'] != 'openSUSE Leap 42.2' %}
       {%- if grains['os'] != 'Windows' and on_docker == False %}
       - mount: add-extra-swap
+      {%- endif %}
       {%- endif %}
       {%- endif %}
       {%- if grains['os'] == 'Windows' %}


### PR DESCRIPTION
Moving the check for OpenSuse to be grains. I am having it be specific to the version of Suse in case we start testing another version and this problem doesn't exist.