### PR TITLE
Install and enable docker on Ubuntu 16

### DIFF
--- a/docker.sls
+++ b/docker.sls
@@ -1,4 +1,5 @@
- {% set on_docker = salt['grains.get']('virtual_subtype', '') in ('Docker',) %}
+{% set on_docker = salt['grains.get']('virtual_subtype', '') in ('Docker',) %}
+{% set docker_pkg = 'docker.io' if salt['grains.get']('os', '') == 'Ubuntu' else 'docker' %}
 
 /usr/bin/busybox:
   file.managed:

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -45,9 +45,10 @@ force-sync-all:
 include:
   # All VMs get docker-py so they can run unit tests
   - python.docker
-  {%- if grains['os'] == 'CentOS' and os_major_release == 7 %}
-  # Docker integration tests only on CentOS 7 (for now)
+  {%- if grains['os'] == 'CentOS' and os_major_release == 7 or grains['os'] == 'Ubuntu' and os_major_release == 16 %}
   - docker
+  {%- endif %}
+  {%- if grains['os'] == 'CentOS' and os_major_release == 7 %}
   - python.zookeeper
   {%- endif %}
   {%- if grains['os'] not in ('Windows',) %}
@@ -212,7 +213,7 @@ clone-salt-repo:
       # All VMs get docker-py so they can run unit tests
       - pip: docker
       # Docker integration tests only on CentOS 7 (for now)
-      {%- if grains['os'] == 'CentOS' and os_major_release == 7 %}
+      {%- if grains['os'] == 'CentOS' and os_major_release == 7 or grains['os'] == 'Ubuntu' and os_major_release == 16 %}
       {%- if on_docker == False %}
       - service: docker
       - pkg: docker


### PR DESCRIPTION
I've tested in an Ubuntu 16.04 vagrant box, and the 16.04 updates repo has an up-to-date release of Docker available. I was able to run all Docker unit and integration tests and they all passed. Ubuntu 16.04 looks to be read to start running Docker integration tests.