### PR TITLE
Pin version of kubernetes to < 4.0

### DIFF
--- a/python/kubernetes.sls
+++ b/python/kubernetes.sls
@@ -5,7 +5,7 @@ include:
 
 kubernetes:
   pip.installed:
-    - name: kubernetes
+    - name: kubernetes < 4.0
     {%- if salt['config.get']('virtualenv_path', None) %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
We need to pin the kubernetes pip package to < 4.0 until https://github.com/saltstack/salt/issues/44701 can be fixed.

There are two kubernetes unit tests failing on the test suite due to the new version. These will fail until we can handle the new version of the API. Let's pin the version to something that is working so we can get see test results more accurately every where else.

Once https://github.com/saltstack/salt/issues/44701 is fixed, we must unpin the version.