### PR TITLE
Remove "futures" package from Python3 state installations

### DIFF
--- a/cloud-only/init.sls
+++ b/cloud-only/init.sls
@@ -16,7 +16,7 @@ include:
   - python.requests
   - python.keyring
   - python.tornado
-  {%- if grains.get('pythonversion')[:2] < [3, 2] %}
+  {%- if not pillar.get('py3', False) %}
   - python.futures
   {%- endif %}
   - cloud-only.azure
@@ -48,7 +48,7 @@ include:
       - pip: keyring
       - pip: azure
       - pip: tornado
-      {%- if grains.get('pythonversion')[:2] < [3, 2] %}
+      {%- if not pillar.get('py3', False) %}
       - pip: futures
       {%- endif %}
       - pkg: sshpass

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -117,7 +117,7 @@ include:
   {%- if grains['os'] != 'Windows' %}
   - gem
   {%- endif %}
-  {%- if grains.get('pythonversion')[:2] < [3, 2] %}
+  {%- if not pillar.get('py3', False) %}
   - python.futures
   {%- endif %}
   {%- if grains['os'] not in ('MacOS', 'Windows') %}
@@ -279,7 +279,7 @@ clone-salt-repo:
       {%- if grains['os'] != 'MacOS' %}
       - pip: pyinotify
       {%- endif %}
-      {%- if grains.get('pythonversion')[:2] < [3, 2] %}
+      {%- if not pillar.get('py3', False) %}
       - pip: futures
       {%- endif %}
       - pip: gitpython


### PR DESCRIPTION
The latest version of the futures package causes a state failure when attempting to install the state on for Python 3. We shouldn't need this package for Python 3 tests, so this should be safe to remove the pip installation on Python 3 test runs.

Fixes #578