### PR TITLE
Only install gcc-multilib on arch

### DIFF
--- a/gcc.sls
+++ b/gcc.sls
@@ -1,16 +1,21 @@
 {% if grains['os'] == 'SmartOS' %}
   {% set gcc = 'gcc47' %}
+{% elif grains['os'] == 'Arch' %}
+  {% if salt['pkg.list_repo_pkgs']('gcc-multilib') %}
+    {% set gcc = 'gcc-multilib' %}
+  {% else %}
+    {% set gcc = 'gcc' %}
+  {% endif %}
 {% else %}
   {% set gcc = 'gcc' %}
 {% endif %}
 
-{%- if grains['os'] == 'Arch' %}
+{% if grains['os'] == 'Arch' and gcc == 'gcc' %}
 gcc-multilib:
   pkg.removed
+{% endif %}
 
-{%- else -%}
 gcc:
   pkg.installed:
     - name: {{ gcc }}
     - aggregate: True
-{%- endif %}

--- a/gcc.sls
+++ b/gcc.sls
@@ -7,8 +7,8 @@
 {%- if grains['os'] == 'Arch' %}
 gcc-multilib:
   pkg.removed
-{%- endif %}
 
+{% else %}
 gcc:
   pkg.installed:
     - name: {{ gcc }}
@@ -17,3 +17,4 @@ gcc:
     - require:
       - pkg: gcc-multilib
     {%- endif %}
+{%- endif %}

--- a/gcc.sls
+++ b/gcc.sls
@@ -8,13 +8,9 @@
 gcc-multilib:
   pkg.removed
 
-{% else %}
+{%- else -%}
 gcc:
   pkg.installed:
     - name: {{ gcc }}
     - aggregate: True
-    {%- if grains['os'] == 'Arch' %}
-    - require:
-      - pkg: gcc-multilib
-    {%- endif %}
 {%- endif %}


### PR DESCRIPTION
We are seeing the following error on arch tests:

```
17:51:33 [ERROR   ] Command '['systemd-run', '--scope', 'pacman', '-S', '-y', '--noprogressbar', '--noconfirm', '--needed', 'npm', 'gcc', 'dmidecode', 'lsb-release', 'bind-tools', 'mysql-python', 'nginx', 'python2-pygit2', 'ruby']' failed with return code: 1
17:51:33 [ERROR   ] stdout: :: Synchronizing package databases...
17:51:33  ec2 is up to date
17:51:33  core is up to date
17:51:33  extra is up to date
17:51:33  community is up to date
17:51:33  multilib is up to date
17:51:33 resolving dependencies...
17:51:33 looking for conflicting packages...
17:51:33 :: gcc-libs and gcc-libs-multilib are in conflict. Remove gcc-libs-multilib? [y/N] 
17:51:33 :: gcc-libs and gcc-libs-multilib are in conflict
17:51:33 [ERROR   ] stderr: Running scope as unit: run-re97182ff4b984411bd2945aebe0443ed.scope
17:51:33 error: unresolvable package conflicts detected
17:51:33 error: failed to prepare transaction (conflicting dependencies)
17:51:33 [ERROR   ] retcode: 1
17:51:33 [INFO    ] Executing command ['pacman', '-Q'] in directory '/root'
17:51:33 [ERROR   ] Problem encountered installing package(s). Additional info follows:
17:51:33 
17:51:33 errors:
17:51:33     - Running scope as unit: run-re97182ff4b984411bd2945aebe0443ed.scope
17:51:33       error: unresolvable package conflicts detected
17:51:33       error: failed to prepare transaction (conflicting dependencies)
```

Here: https://jenkins.saltstack.com/job/Oxygen/job/oxygen-salt-arch-py2/23/consoleFull

With the latest arch update gcc and gcc-multilib would conflict with each other so you can not have both installed. This state will ensure only multilib is installed for arch.

You can also see this forum for more context: https://bbs.archlinux.org/viewtopic.php?id=226723

