### PR TITLE
Fix transport req installs for tcp py3

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -370,11 +370,13 @@ fetch-upstream-tags:
 
 {%- if pillar.get('py3', False) %}
 {#- Install Salt Dev Dependencies #}
-{% for req in transport_reqs %}
+{%- if test_transport in ('zeromq', 'raet') -%}
+  {% for req in transport_reqs %}
 install-transport-{{ req }}:
   pip.installed:
     - name: {{ req }}
-{% endfor %}
+  {% endfor %}
+{%- endif -%}
 
 {% for req in dev_reqs %}
 install-dev-{{ req }}:


### PR DESCRIPTION
Fixes https://github.com/saltstack/salt-jenkins/issues/613

**Note**: This will need to be merged forward to oxygen after merged as this effects both 2017.7 and oxygen.