### PR TITLE
Fixing MAC node issue with 7.0.0 of node not being available

### DIFF
--- a/bower.sls
+++ b/bower.sls
@@ -4,10 +4,14 @@ nodejs-legacy:
       - aggregate: True
 {% endif %}
 
+
+{# for MacOS we want to install node, npm, and bower at the end for issue #41770, so skipping install here. #}
+{% if grains['os'] != 'MacOS' %}
 bower:
   npm.installed:
     - require:
       - pkg: npm
+{% endif %}
       {# we expect OSX to have git available from the system, not the package manager (brew) #}
       {% if grains['os'] != 'MacOS' %}
       - pkg: git

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -326,7 +326,7 @@ clone-salt-repo:
       {%- endif %}
       - pip: dnspython
       {%- if (grains['os'] not in ['Debian', 'Ubuntu', 'openSUSE'] and not grains['osrelease'].startswith('5.')) or (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('14.')) %}
-      {%- if grains['os'] != 'Windows' %}
+      {%- if grains['os'] not in ('MacOS', 'Windows') %}
       - pkg: npm
       - npm: bower
       {%- endif %}
@@ -413,18 +413,24 @@ install-salt-pytest-pip-deps:
 {%- endif %}
 
 {# npm v5 workaround for issue #41770 #}
+{# node version 7.0.0 is not avaliable in MAC OSX 13(High Sierra) #}
+{# installing node, npm, and bower manually for the MAC OS. #}
 {%- if grains['os'] == 'MacOS' %}
-downgrade_node:
-  cmd.run:
-    - name: 'brew switch node 7.0.0'
-    - runas: jenkins
+download_node:
+  file.managed:
+    - source: https://nodejs.org/download/release/v7.0.0/node-v7.0.0.pkg 
+    - source_hash: sha256=5d935d0e2e864920720623e629e2d4fb0d65238c110db5fbe71f73de8568c024
+    - name: /tmp/node-v7.0.0.pkg
+    - user: root
+    - group: wheel
 
-downgrade_npm:
+install_node:
+  macpackage.installed:
+    - name: /tmp/node-v7.0.0.pkg
+    - reload_modules: True
+
+bower:
   npm.installed:
-    - name: npm@3.10.8
-
-pin_npm:
-  cmd.run:
-    - name: 'brew pin node'
-    - runas: jenkins
+    - require:
+      - macpackage: install_node 
 {%- endif %}


### PR DESCRIPTION
In `MAC OSX 10.13` there was no brew package for `node v7.0.0`, so I made it install that from a mac `.pkg` file.

It installs `npm` that is bundled with it. I also needed `bower` to install after we install the `npm` that was packaged with `node 7.0.0` so I moved it to install at the end.

This fix has been tested with `OSX 10.11`, `10.12`, and `10.13`. 