### PR TITLE
ensure installing latest tornado

### DIFF
--- a/python/tornado.sls
+++ b/python/tornado.sls
@@ -5,6 +5,7 @@ include:
 
 tornado:
   pip.installed:
+    - upgrade: True
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
On debian 8 tests we are running into this https://github.com/tornadoweb/tornado/issues/1573 because there are two addresses for locahost on that VM. 

When setting up the tests we don't install anything past tornado 4.2.1 which is the affected version and as you can see in the state below it keeps it at the installed version because we don't pass in upgrade option.

```
18:06:52 ----------
18:06:52           ID: tornado
18:06:52     Function: pip.installed
18:06:52         Name: tornado>=4.2.1,<4.5.0
18:06:52       Result: True
18:06:52      Comment: Python package tornado>=4.2.1,<4.5.0 was already installed
18:06:52               All packages were successfully installed
18:06:52      Started: 18:04:12.512862
18:06:52     Duration: 1063.907 ms
18:06:52      Changes:   
18:06:52 ----------
```

note: this might affect many tests as we might be changing the version of tornado for our tests. Just a mental note if we start seeing failures.

Fixes: https://github.com/saltstack/salt-jenkins/issues/549