### PR TITLE
pin tornado to old version for py26

### DIFF
--- a/python/tornado.sls
+++ b/python/tornado.sls
@@ -3,9 +3,15 @@ include:
   - python.pip
 {% endif %}
 
+{% set on_py26 = True if grains.get('pythonexecutable', '').endswith('2.6') else False %}
+
 tornado:
   pip.installed:
+  {%- if on_py26 %}
+    - name: tornado==4.4.3
+  {%- else %}
     - upgrade: True
+  {%- endif %}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
This version of tornado is before they added using `memoryview` which is causing this error

Fixes https://github.com/saltstack/salt-jenkins/issues/715