### PR TITLE
remove upgrade from pip for tornado

### DIFF
--- a/python/tornado.sls
+++ b/python/tornado.sls
@@ -4,13 +4,15 @@ include:
 {% endif %}
 
 {% set on_py26 = True if grains.get('pythonexecutable', '').endswith('2.6') else False %}
+{% set debian8 = grains.os == 'Debian' and grains.osmajorrelease|int == 8 %} 
+
 
 tornado:
   pip.installed:
-  {%- if on_py26 %}
+  {%- if on_py26 or debian8 %}
     - name: tornado==4.4.3
   {%- else %}
-    - upgrade: True
+    - name: tornado
   {%- endif %}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}


### PR DESCRIPTION
also pin debian 8 to 4.4.3 so that it gets the newer version, but does
not require --upgrade, which causes a segfault on centos 7 for some
reason.

Fixes #717