### PR TITLE
rename timelib id for requirement

### DIFF
--- a/python/timelib.sls
+++ b/python/timelib.sls
@@ -20,7 +20,7 @@ get-timelib-zip:
     - source_hash: sha512=0cb0b2f6a6249c38c8a5e043bcafde6f83f84d1d10f942d41dd8ff35f91df06b492811dbc896890a83c7feab17ba253c1517b93c9216a88e9e870e7465ac7a51
     - archive_format: zip
 
-install-timelib:
+timelib:
   cmd.run:
     - name: make install
     - cwd: {{ timelib_dir }}/timelib-0.2.4/


### PR DESCRIPTION
fixes this error we are running on mac now:

```
17:46:10 ----------
17:46:10           ID: clone-salt-repo
17:46:10     Function: git.latest
17:46:10         Name: https://github.com/saltstack/salt.git
17:46:10       Result: False
17:46:10      Comment: The following requisites were not found:
17:46:10                                  require:
17:46:10                                      pip: timelib
17:46:10      Started: 
17:46:10     Duration: 
17:46:10      Changes:   
17:46:10 ----------
```