### PR TITLE
[2017.7] Merge forward from 2016.11 to 2017.7

### DIFF
--- a/python/tornado.sls
+++ b/python/tornado.sls
@@ -3,12 +3,17 @@ include:
   - python.pip
 {%- endif %}
 
-{%- set pinned_pkg = 'tornado>=4.2.1,<4.5.0' %}
+{% set on_py26 = True if grains.get('pythonexecutable', '').endswith('2.6') else False %}
+{% set debian8 = grains.os == 'Debian' and grains.osmajorrelease|int == 8 %} 
+
 
 tornado:
   pip.installed:
-    - name: {{ pinned_pkg }}
-    - upgrade: True
+  {%- if on_py26 or debian8 %}
+    - name: tornado==4.4.3
+  {%- else %}
+    - name: tornado
+  {%- endif %}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Conflicts:
  - python/tornado.sls

@gtmanfred Here's using the way we're doing this in 2016.11 instead of the "pinned packages". Let's see how that goes instead.

Refs #754