### PR TITLE
libuv arch workaround fix

### DIFF
--- a/npm.sls
+++ b/npm.sls
@@ -1,3 +1,4 @@
+{% set arch = True if grains['os_family'] == 'Arch' else False %}
 {% set suse = True if grains['os_family'] == 'Suse' else False %}
 {% set freebsd = True if grains['os'] == 'FreeBSD' else False %}
 {% set macos = True if grains['os'] == 'MacOS' else False %}
@@ -18,10 +19,19 @@
 npm:
   pkg.installed:
     - pkgs:
-{% if suse %} 
+{% if suse %}
       - {{ nodejs }}
       - {{ npm }}
 {% else %}
       - {{ npm }}
     - aggregate: True
+{% endif %}
+
+{# workaround for https://github.com/npm/npm/issues/19634 #}
+{% if arch %}
+libuv:
+  pkg.installed:
+    - reinstall: True
+    - sources:
+      - libuv: https://archive.archlinux.org/packages/l/libuv/libuv-1.18.0-1-x86_64.pkg.tar.xz
 {% endif %}


### PR DESCRIPTION
Currently we are running into this issue when attempting to bootstrap arch boxes on 2016.11.9:

```
14:19:40 ----------
14:19:40           ID: bower
14:19:40     Function: npm.installed
14:19:40       Result: False
14:19:40      Comment: Error looking up 'bower': Error: read ENOTCONN
14:19:40                   at _errnoException (util.js:1003:13)
14:19:40                   at Socket._read (net.js:495:20)
14:19:40                   at Socket.Readable.read (_stream_readable.js:449:10)
14:19:40                   at Socket.read (net.js:376:43)
14:19:40                   at new Socket (net.js:259:12)
14:19:40                   at createSocket (internal/child_process.js:241:11)
14:19:40                   at ChildProcess.spawn (internal/child_process.js:357:23)
14:19:40                   at exports.spawn (child_process.js:499:9)
14:19:40                   at Object.exports.execFile (child_process.js:209:15)
14:19:40                   at uidNumber (/usr/lib/node_modules/npm/node_modules/uid-number/uid-number.js:33:17)
14:19:40                   at Conf.loadUid (/usr/lib/node_modules/npm/lib/config/load-uid.js:11:5)
14:19:40                   at Conf.<anonymous> (/usr/lib/node_modules/npm/lib/config/core.js:235:10)
14:19:40                   at Conf.setUser (/usr/lib/node_modules/npm/lib/config/set-user.js:15:34)
14:19:40                   at Conf.loadExtras (/usr/lib/node_modules/npm/lib/config/core.js:233:8)
14:19:40                   at Conf.<anonymous> (/usr/lib/node_modules/npm/lib/config/core.js:173:12)
14:19:40                   at Object.onceWrapper (events.js:255:19)
14:19:40               /usr/lib/node_modules/npm/lib/npm.js:61
14:19:40                     throw new Error('npm.load() required')
14:19:40                     ^
14:19:40               
14:19:40               Error: npm.load() required
14:19:40                   at Object.get (/usr/lib/node_modules/npm/lib/npm.js:61:13)
14:19:40                   at process.errorHandler (/usr/lib/node_modules/npm/lib/utils/error-handler.js:205:18)
14:19:40                   at process.emit (events.js:160:13)
14:19:40                   at process._fatalException (bootstrap_node.js:386:26)
14:19:40      Started: 14:18:53.632357
14:19:40     Duration: 315.587 ms
14:19:40      Changes: 
```

This is caused by https://github.com/npm/npm/issues/19634

This is a current workaround until the fix is made available in package form.

To note when trying to use this state in the PR with version 2017.7 it didn't work and the issue is here: https://github.com/saltstack/salt/issues/45527

since we use 2016.11 for the tests this should not be an issue as I've tested there and it works fine. 