### PR TITLE
[2016.11 only] update PATH for 2016.11 Mac

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -38,6 +38,9 @@
 {%- endif %}
 
 include:
+  {%- if grains['os'] == 'MacOS' %}
+  - python.path
+  {% endif %}
   # All VMs get docker-py so they can run unit tests
   - python.docker
   {%- if grains['os'] == 'CentOS' and grains['osmajorrelease']|int == 7 %}

--- a/python/path.sls
+++ b/python/path.sls
@@ -1,0 +1,9 @@
+{# workaround only needs to be in 2016.11 branch #}
+{%- if grains['os'] in ('MacOS') %}
+  {% set pythonpath = 'export PATH=/opt/salt/bin/:$PATH' %}
+{% endif %}
+python-path:
+  file.append:
+    - name: /etc/profile
+    - text: |
+        {{ pythonpath }}


### PR DESCRIPTION
Running into this stack trace when attempting to start the test runner:

```
 * Starting salt-minion ... Traceback (most recent call last):                                                                          
  File "/private/tmp/salt-tests-tmpdir/scripts/cli_salt_run.py", line 10, in <module>                                                   
    from salt.utils import is_windows                                                                                                   
  File "/testing/salt/utils/__init__.py", line 35, in <module>                                                                          
    import tempfile                                                                                                                     
  File "/opt/salt/lib/python2.7/tempfile.py", line 32, in <module>                                                                      
    import io as _io                                                                                                                    
  File "/opt/salt/lib/python2.7/io.py", line 51, in <module>                                                                            
    import _io                                                                                                                          
ImportError: dlopen(/opt/salt/lib/python2.7/lib-dynload/_io.so, 2): Symbol not found: __PyCodecInfo_GetIncrementalDecoder               
  Referenced from: /opt/salt/lib/python2.7/lib-dynload/_io.so
  Expected in: dynamic lookup
```

There is a conflict with the test python version and system version for mac so updating path for mac.