### PR TITLE
add pkg_resources to pip stuff

### DIFF
--- a/_modules/pip.py
+++ b/_modules/pip.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 import os
 import types
 import logging
+import pkg_resources
 
 # Import salt libs
 import salt.utils

--- a/_states/pip2_state.py
+++ b/_states/pip2_state.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 import os
 import types
 import logging
+import pkg_resources
 
 # Import salt libs
 from salt.utils import namespaced_function

--- a/_states/pip3_state.py
+++ b/_states/pip3_state.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 import os
 import types
 import logging
+import pkg_resources
 
 # Import salt libs
 from salt.utils import namespaced_function

--- a/_states/pip_state.py
+++ b/_states/pip_state.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import
 import os
 import types
+import pkg_resources
 
 # Import salt libs
 from salt.utils import namespaced_function


### PR DESCRIPTION
new import added in 2017.7.3

Since we namespace all the functions if we want to use 2017.7.3 to bootstrap minions for testing, we need this change