### PR TITLE
restrict boto to >= 2.46.0

### DIFF
--- a/python/boto.sls
+++ b/python/boto.sls
@@ -5,7 +5,7 @@ include:
 
 boto:
   pip.installed:
-    - name: boto >= 2.33.0
+    - name: boto >= 2.46.0
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Boto changed the endpoints.json file structure, and if boto is already
installed, it will need to be upgrade to newer than 2.46.0