### PR TITLE
Upgrade mock version for Ubuntu 14

### DIFF
--- a/python/mock.sls
+++ b/python/mock.sls
@@ -3,9 +3,15 @@ include:
   - python.pip
 {% endif %}
 
+{%- if grains['os'] == 'Ubuntu' and grains.get('osrelease', '').startswith('14') %}
+  {%- set pinned_mock = 'mock' %}
+{%- else %}
+  {%- set pinned_mock = 'mock < 1.1.0' %}
+{%- endif %}
+
 mock:
   pip.installed:
-    - name: 'mock < 1.1.0'
+    - name: {{ pinned_mock }}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Old versions of mock have problems with memory. We pinned the version of mock nearly 3 years ago, so let's upgrade it now. However, let's do it slowly and see how we do on Ubuntu 14 rather than everything all at once.