### PR TITLE
Making OpenSuse skip the add-extra-swap state

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -243,7 +243,7 @@ clone-salt-repo:
       {%- if grains['os'] == 'FreeBSD' %}
       - cmd: add-extra-swap
       {%- else %}
-      {%- if salt['grains.get']('os', '') != 'openSUSE Leap' %}
+      {%- if salt.grains.get('os_family') not in ('Suse', ) %}  
       {%- if grains['os'] != 'Windows' and on_docker == False %}
       - mount: add-extra-swap
       {%- endif %}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -243,7 +243,7 @@ clone-salt-repo:
       {%- if grains['os'] == 'FreeBSD' %}
       - cmd: add-extra-swap
       {%- else %}
-      {%- if salt['grains.get']('oscodename', '') != 'openSUSE Leap 42.2' %}
+      {%- if salt['grains.get']('os', '') != 'openSUSE Leap' %}
       {%- if grains['os'] != 'Windows' and on_docker == False %}
       - mount: add-extra-swap
       {%- endif %}


### PR DESCRIPTION
Skipping add-extra swap space on OpenSuse at this time. Once we get the Python issues resolved we can go back and fix this state.

This should fix the tests for Python3 Open Suse for the time being.