### PR TITLE
Use newer mock on all platforms

### DIFF
--- a/python/mock.sls
+++ b/python/mock.sls
@@ -3,15 +3,8 @@ include:
   - python.pip
 {% endif %}
 
-{%- if grains['os'] in ('Debian', 'Ubuntu') %}
-  {%- set pinned_mock = 'mock' %}
-{%- else %}
-  {%- set pinned_mock = 'mock < 1.1.0' %}
-{%- endif %}
-
 mock:
   pip.installed:
-    - name: {{ pinned_mock }}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
This was pinned to an older version due for Python 2.6 compatibility, but since we no longer support 2.6, it's no longer necessary.