### PR TITLE
Add name for Windows

### DIFF
--- a/python/mock.sls
+++ b/python/mock.sls
@@ -5,6 +5,7 @@ include:
 
 mock:
   pip.installed:
+    - name: mock
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}


### PR DESCRIPTION
Since all the code under the salt state is gated on Window, we need to at least have the name parameter defined. Otherwise, we end up with an invalid state.