### PR TITLE
Ensure GitPython Installing >=2.1.8

### DIFF
--- a/python/gitpython.sls
+++ b/python/gitpython.sls
@@ -10,7 +10,7 @@ gitpython:
     # available in Python 2.6
     - name: 'GitPython < 2.0.9'
     {%- else %}
-    - name: GitPython
+    - name: GitPython>=2.1.8
     {%- endif %}
     {%- if salt['config.get']('virtualenv_path', None)  %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}


### PR DESCRIPTION
gitfs mac tests are failing:

```
*** unit.fileserver.test_gitfs.GitPythonTest Tests  ***************************************************************
 --------  Tests with Errors  -------------------------------------------------------------------------------------
   -> setUpClass (unit.fileserver.test_gitfs.GitPythonTest)  ......................................................
       Traceback (most recent call last):
         File "/testing/tests/unit/fileserver/test_gitfs.py", line 418, in setUpClass
           repo.index.commit('Test')
         File "/opt/salt/lib/python2.7/site-packages/git/index/base.py", line 922, in commit
           tree = self.write_tree()
         File "/opt/salt/lib/python2.7/site-packages/git/index/base.py", line 519, in write_tree
           entries = self._entries_sorted()
         File "/opt/salt/lib/python2.7/site-packages/git/index/base.py", line 173, in _entries_sorted
           return sorted(self.entries.values(), key=lambda e: (e.path, e.stage))
         File "/opt/salt/lib/python2.7/site-packages/gitdb/util.py", line 256, in __getattr__
           self._set_cache_(attr)
         File "/opt/salt/lib/python2.7/site-packages/git/index/base.py", line 139, in _set_cache_
           self._deserialize(stream)
         File "/opt/salt/lib/python2.7/site-packages/git/index/base.py", line 168, in _deserialize
           self.version, self.entries, self._extension_data, conten_sha = read_cache(stream)
         File "/opt/salt/lib/python2.7/site-packages/git/index/fun.py", line 187, in read_cache
           path = read(path_size).decode(defenc)
         File "/opt/salt/lib/python2.7/encodings/utf_8.py", line 16, in decode
           return codecs.utf_8_decode(input, errors, True)
       UnicodeDecodeError: 'utf8' codec can't decode byte 0xd0 in position 8: unexpected end of data
```

We need to ensure GitPython installs atleast 2.1.8 as it is not handling the unicode in earlier versions. An older version of GitPython is already installed on these mac images so this will ensure this version or later is installed instead of what is already installed. 