### PR TITLE
Add mac python path to /etc/profile

### DIFF
--- a/python/path.sls
+++ b/python/path.sls
@@ -5,3 +5,5 @@ fix path for mac:
         - text: 'session    optional       pam_env.so'
       - /etc/environment:
         - text: 'export PATH=/opt/salt/bin/:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/salt/bin:/usr/local/sbin'
+      - /etc/profile:
+        - text: 'export PATH=/opt/salt/bin/:$PATH'


### PR DESCRIPTION
was removed here: https://github.com/saltstack/salt-jenkins/pull/852 and resulted in the tests `integration.netapi.test_client` to fail on python3 because the ssh minion was not returning because it could not find python in the path.