### PR TITLE
Pinning the tornado version to match requirements

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -45,7 +45,7 @@
 {% endif %}
 
 {% set dev_reqs = ['mock', 'apache-libcloud>=0.14.0', 'boto>=2.32.1', 'boto3>=1.2.1', 'moto>=0.3.6', 'SaltTesting>=2016.10.26', 'SaltPyLint'] %}
-{% set base_reqs = ['Jinja2', 'msgpack-python>0.3', 'PyYAML', 'MarkupSafe', 'requests>=1.0.0', 'tornado>=4.2.1'] %}
+{% set base_reqs = ['Jinja2', 'msgpack-python>0.3', 'PyYAML', 'MarkupSafe', 'requests>=1.0.0', 'tornado>=4.2.1,<5.0'] %}
 
 include:
   {%- if grains.get('kernel') == 'Linux' %}


### PR DESCRIPTION
Updated tornado requirements to be `tornado>=4.2.1,<5.0`