### PR TITLE
Unpin virtualenv version

### DIFF
--- a/python/virtualenv.sls
+++ b/python/virtualenv.sls
@@ -1,9 +1,4 @@
-{%- if pillar.get('py3', False) %}
-  {#- pip==1.10 does not work on python 3.4 #}
-  {%- set virtualenv_pin = '' %}
-{%- else %}
-  {%- set virtualenv_pin = '' if grains['os'] == 'MacOS' else '==1.10' %}
-{% endif %}
+{%- set virtualenv_pin = '' %}
 
 {% if grains['os'] != 'Windows' %}
 include:


### PR DESCRIPTION
We pinned to version 1.10 because of this issue, I believe: https://github.com/pypa/virtualenv/issues/524

Virtualenv 1.10 doesn't have the `--no-cache-dir` option and was causing some test failures.

We're not pinning on MacOS nor on Py3. Version 1.10 is from 2013, hopefully they've fixed any issues since then.