### PR TITLE
import disutils.version if salt.utils.version not available

### DIFF
--- a/_modules/pip.py
+++ b/_modules/pip.py
@@ -17,12 +17,15 @@ import pkg_resources
 # Import salt libs
 import salt.utils
 from salt.utils import namespaced_function
-from salt.utils.versions import LooseVersion
 from salt.exceptions import CommandNotFoundError
 import salt.modules.pip
 from salt.modules.pip import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from salt.modules.pip import install as pip_install
 from salt.modules.pip import list_ as pip_list
+try:
+    from salt.utils.versions import LooseVersion
+except ImportError:
+    from distutils.version import LooseVersion
 
 # Import 3rd Party libs
 import salt.ext.six as six


### PR DESCRIPTION
Currently on macosx pip.installed states are failing because it cannot import salt.utils.version since they bootstrap an older version. We cannot currently upgrade the bootstrap version due to this issue: https://github.com/saltstack/salt-jenkins/issues/976 so this is the workaround until that is fixed. 