### PR TITLE
Add cloud dependencies to centos 7

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -17,6 +17,7 @@ provisioner:
     $OldPath = (Get-ItemProperty -Path "$Reg" -Name PATH).Path
     $NewPath= $OldPath + ';' + $AddedLocation
     Set-ItemProperty -Path "$Reg" -Name PATH -Value $NewPath
+    cmd.exe /c "c:\python27\python.exe -m pip install pip==9.0.3 2>&1"
   is_file_root: true
   salt_copy_filter:
     - .bundle

--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -9,6 +9,7 @@ driver:
 
 provisioner:
   name: salt_solo
+  salt_version: 2017.7.4
   init_environment: |
     Clear-Host
     $AddedLocation ="c:\salt"
@@ -39,8 +40,6 @@ platforms:
       username: <%= ENV["winrm_user"] %>
       password: <%= ENV["winrm_pass"] %>
       port: <%= ENV["winrm_port"] %>
-      salt_bootstrap_url: https://raw.githubusercontent.com/saltstack/salt-bootstrap/develop/bootstrap-salt.ps1
-      salt_bootstrap_options: '-version 2017.7.0'
 
 suites:
   - name: py2

--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -39,6 +39,8 @@ platforms:
       username: <%= ENV["winrm_user"] %>
       password: <%= ENV["winrm_pass"] %>
       port: <%= ENV["winrm_port"] %>
+      salt_bootstrap_url: https://raw.githubusercontent.com/saltstack/salt-bootstrap/develop/bootstrap-salt.ps1
+      salt_bootstrap_options: '-version 2017.7.0'
 
 suites:
   - name: py2

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -66,6 +66,9 @@ include:
   {%- if grains['os'] == 'CentOS' and os_major_release == 7 %}
   # Docker integration tests only on CentOS 7 (for now)
   - docker
+  # Windows cloud tests
+  - python.impacket
+  - python.winrm
   {%- endif %}
   {%- if grains['os'] == 'Ubuntu' and os_major_release >= 17 %}
   - dpkg

--- a/python/impacket.sls
+++ b/python/impacket.sls
@@ -1,0 +1,5 @@
+{% if grains['os'] in ('CentOS',) %}
+impacket:
+  pkg.installed:
+    - name: python2-impacket
+{% endif %}

--- a/python/winrm.sls
+++ b/python/winrm.sls
@@ -1,0 +1,5 @@
+{% if grains['os'] in ('CentOS',) %}
+winrm:
+  pkg.installed:
+    - name: python2-winrm
+{% endif %}


### PR DESCRIPTION
Install impacket and winrm for windows cloud tests (python 2). Impacket is not py3 compatible.