### PR TITLE
Add cron install to git.salt

### DIFF
--- a/cron.sls
+++ b/cron.sls
@@ -1,0 +1,4 @@
+{% if salt['grains.get']('os_family') == 'RedHat' %}
+cronie:
+  pkg.installed
+{% endif %}

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -173,6 +173,7 @@ include:
   {%- endif %}
   - python.dns
   - python.croniter
+  - cron
   {%- if (grains['os'] not in ['Debian', 'Ubuntu', 'openSUSE', 'Windows'] and not grains['osrelease'].startswith('5.')) or (grains['os'] == 'Ubuntu' and grains['osrelease'].startswith('14.')) %}
   - npm
   - bower


### PR DESCRIPTION
crontab is not installed on fedora 28 and its causing this test to fail: `integration.states.test_cron.CronTest.test_managed`