### PR TITLE
Removing GCC Compiler from MAC due to broken pip

### DIFF
--- a/python/pyzmq.sls
+++ b/python/pyzmq.sls
@@ -11,7 +11,7 @@ include:
 {%- endif %}
 
 pyzmq:
-  {%- if grains['os_family'] not in ('Arch', 'Windows') %}
+  {%- if grains['os_family'] not in ('Arch', 'Windows', 'MacOS') %}
   pkg.installed:
     - name: {{ 'g++' if grains.os_family == 'Debian' else 'gcc-c++' }}
   {%- endif %}


### PR DESCRIPTION
Adding MACOS to the list to skip GCC install