### PR TITLE
ensure bower is upgraded by adding force_reinstall arg

### DIFF
--- a/bower.sls
+++ b/bower.sls
@@ -23,6 +23,7 @@ bower:
   npm.installed:
     {%- if ubuntu14 or centos6 %}
     - registry: http://registry.npmjs.org/
+    - force_reinstall: True
     {%- endif %}
     - require:
       - pkg: npm


### PR DESCRIPTION
Currently these tests are failing on macosx sierra:

integration.states.test_bower.BowerStateTest.test_bower_installed_from_file
integration.states.test_bower.BowerStateTest.test_bower_installed_pkgs
integration.states.test_bower.BowerStateTest.test_bower_installed_removed

this is because the seirra os image we use already has an older version of bower installed which uses an old registry that has since been deprecated. On solution is to edit the bower configuration file and add the new registry or upgrade the package. I  think upgrading the package is the best solution as we want to ensure we are testing the new version anyways