### PR TITLE
Fix git state wart

### DIFF
--- a/git/init.sls
+++ b/git/init.sls
@@ -14,7 +14,7 @@ include:
 {%- endif %}
 
 git:
-{% if grains['os_family'] == 'Windows' %}
+{% if grains['os'] == 'Windows' %}
   module.run:
     - name: winrepo_pkg.install
     - args:


### PR DESCRIPTION
Git is not getting installed when this state runs. This fixes the exception in `unit.fileserver.test_gitfs.GitPythonTest.setUpClass`. Including this causes the setup method to succeed allowing these test to run, 9 of them will fail when run.