### PR TITLE
force-reinstall bower for only macosx

### DIFF
--- a/bower.sls
+++ b/bower.sls
@@ -23,7 +23,6 @@ bower:
   npm.installed:
     {%- if ubuntu14 or centos6 %}
     - registry: http://registry.npmjs.org/
-    - force_reinstall: True
     {%- endif %}
     - require:
       - pkg: npm

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -461,6 +461,7 @@ install_node:
 
 bower:
   npm.installed:
+    - force_reinstall: True
     - require:
       - macpackage: install_node
 


### PR DESCRIPTION
reverts https://github.com/saltstack/salt-jenkins/pull/1038

and adds `- force_reinstall: True` in the correct bower state used by macosx.

This will fix the following test failures:

integration.states.test_bower.BowerStateTest.test_bower_installed_from_file
integration.states.test_bower.BowerStateTest.test_bower_installed_pkgs
integration.states.test_bower.BowerStateTest.test_bower_installed_removed