### PR TITLE
Run gpg state for macosx

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -181,7 +181,7 @@ include:
   - npm
   - bower
   {%- endif %}
-  {%- if grains['os'] == 'Fedora' or (grains['os'] == 'CentOS' and os_major_release == 5) %}
+  {%- if grains['os'] in ('Fedora', 'MacOS') or (grains['os'] == 'CentOS' and os_major_release == 5) %}
   - gpg
   {%- endif %}
   {%- if grains['os'] == 'Fedora' %}


### PR DESCRIPTION
this test is failing on `unit.modules.test_gpg.GpgTestCase.test_delete_key` macosx because gpg is not installed. 