### PR TITLE
Pin boto3 to < 1.8.0 to fix Windows test failures

### DIFF
--- a/python/boto.sls
+++ b/python/boto.sls
@@ -31,7 +31,11 @@ boto:
 
 boto3:
   pip.installed:
+{% if grains['os'] in ('Windows',) %}
+    - name: boto3 < 1.8.0
+{% else %}
     - name: boto3
+{% endif %}
     - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
     - cwd: {{ salt['config.get']('pip_cwd', '') }}
     {%- if salt['config.get']('pip_target', None)  %}


### PR DESCRIPTION
Pinning boto3 to fix new boto test failures: https://jenkinsci.saltstack.com/job/2017.7/job/salt-windows-2016-py2/lastCompletedBuild/testReport/