### PR TITLE
Use rvm to install ruby on OSX

### DIFF
--- a/curl.sls
+++ b/curl.sls
@@ -20,6 +20,15 @@ include:
   {%- endif %}
 {%- endif %}
 
+{%- if grains['os_family'] == 'Darwin' %}
+mac-ruby-upgrade:
+  rvm.installed:
+    - name: ruby-2.4.4
+    - default: true
+    - require_in:
+      - pkg: curl
+{%- endif %}
+
 curl:
   {{ install_method }}:
     - name: {{ curl }}


### PR DESCRIPTION
Brew seems not to work with the current version of ruby in Sierra, as it
requires >2.3 and 2.0 is the default on Sierra.

I haven't tested this yet, but it should only do things to darwin systems. 

@Ch3LL 