### PR TITLE
Pin CherryPy version to 17.3.0

### DIFF
--- a/python/cherrypy.sls
+++ b/python/cherrypy.sls
@@ -7,7 +7,7 @@ include:
 
 cherrypy:
   pip.installed:
-    - name: cherrypy
+    - name: 'cherrypy==17.3.0'
     - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
     - cwd: {{ salt['config.get']('pip_cwd', '') }}
     {%- if salt['config.get']('pip_target', None)  %}


### PR DESCRIPTION
The v18.0 version requires Python 3.5