### PR TITLE
Updating MAC Py3 

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -318,8 +318,10 @@ clone-salt-repo:
       - pip: keyring
       - pip: gnupg
       - pip: python-etcd
-      {% if not ( pillar.get('py3', False) and grains['os'] == 'Windows' ) %}
+      {% if not ( pillar.get('py3', False) and grains['os'] in ('Windows', 'MacOS')) %} 
       - pip2: supervisor
+      {% elif not ( pillar.get('py3', False) and grains['os'] == 'MacOS') %}
+      - pkg: supervisor
       {% endif %}
       - pip: boto
       - pip: moto

--- a/python/pip.sls
+++ b/python/pip.sls
@@ -113,7 +113,7 @@ upgrade-installed-pip2:
     - require:
       - cmd: pip2-install
 
-{% elif ( pillar.get('py3', False) and grains['os'] in 'MacOS') %}
+{% elif ( pillar.get('py3', False) and grains['os'] == 'MacOS') %}
 pip2-install:
   cmd.run:
     - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && python2 get-pip.py 'pip<=9.0.1'

--- a/python/pip.sls
+++ b/python/pip.sls
@@ -89,7 +89,7 @@ upgrade-installed-pip:
     - require:
       - cmd: pip-install
 
-{%- if pillar.get('py3', False) %}
+{%- if pillar.get('py3', False) and grains['os'] != 'MacOS' %}
 pip2-install:
   cmd.run:
     - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && python2 get-pip.py 'pip<=9.0.1'
@@ -108,6 +108,24 @@ upgrade-installed-pip2:
   pip2.installed:
     - name: pip <=9.0.1
     - upgrade: True
+    - bin_env: {{salt.config.get('virtualenv_path', '')}}
+    - cwd: {{ salt['config.get']('pip_cwd', '') }}
+    - require:
+      - cmd: pip2-install
+
+{% elif ( pillar.get('py3', False) and grains['os'] in 'MacOS') %}
+pip2-install:
+  cmd.run:
+    - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && python2 get-pip.py 'pip<=9.0.1'
+    - cwd: /
+    - reload_modules: True
+    - require:
+      - pkg: curl
+
+upgrade-installed-pip2:
+  cmd.run:
+    - name: pip install --upgrade pip==9.0.1
+    - reload_modules: True
     - bin_env: {{salt.config.get('virtualenv_path', '')}}
     - cwd: {{ salt['config.get']('pip_cwd', '') }}
     - require:

--- a/python/supervisor.sls
+++ b/python/supervisor.sls
@@ -3,8 +3,13 @@ include:
   - python.pip
 {%- endif %}
 
+{%- if grains['os'] == 'MacOS' %}
+  {% set install_type = 'pkg.installed' %}
+{% else %}
+  {% set install_type = 'pip2.installed' %}
+{%- endif %}
 supervisor:
-  pip2.installed:
+  {{ install_type }}:
     - name: supervisor
     - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
     - cwd: {{ salt['config.get']('pip_cwd', '') }}


### PR DESCRIPTION
Updating MAC Py3 git.salt states so that Brew, Pip and some other packages work.

Shouldn't break other Mac OSX versions, although there is a possibility