### PR TITLE
Update to azure 3.0 on centos

### DIFF
--- a/cloud-only/azure.sls
+++ b/cloud-only/azure.sls
@@ -3,11 +3,7 @@ include:
 
 azure:
   pip.installed:
-    {%- if (grains['os'] == 'CentOS') %}
-    - name: azure==1.0.2
-    {%- else %}
     - name: azure
-    {%- endif %}
     - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
     - cwd: {{ salt['config.get']('pip_cwd', '') }}
     - require:


### PR DESCRIPTION
Just unpins azure so we don't fail on python 3.