### PR TITLE
Update pip install command

### DIFF
--- a/python/pip.sls
+++ b/python/pip.sls
@@ -71,7 +71,8 @@ force-sync-all:
 
 pip-install:
   cmd.run:
-    - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && {{ get_pip }} 'pip<=9.0.1'
+    # -c <() because of https://github.com/pypa/get-pip/issues/37
+    - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && {{ get_pip }} -c <(echo 'pip<=9.0.1')
     - cwd: /
     - reload_modules: True
     {%- if os != 'Fedora' %}
@@ -102,7 +103,8 @@ upgrade-installed-pip:
 {%- if pillar.get('py3', False) and os != 'Windows' %}
 pip2-install:
   cmd.run:
-    - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && python2 get-pip.py 'pip<=9.0.1'
+    # -c <() because of https://github.com/pypa/get-pip/issues/37
+    - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && python2 get-pip.py -c <(echo 'pip<=9.0.1')
     - cwd: /
     - reload_modules: True
     {%- if os != 'Fedora' %}


### PR DESCRIPTION
`get-pip.py` is no longer working with just specifying a pip version on
the command line (see pypa/get-pip#37 ) so we have to do some shell
redirection for a constraints file. This will cause us to install pip
9.0.1 or less, as intended. It *should* work. This also modifies the
python 2 version.

@dubb-b 