### PR TITLE
Update pip install command

### DIFF
--- a/python/pip.sls
+++ b/python/pip.sls
@@ -59,7 +59,8 @@ include:
 
 pip-install:
   cmd.run:
-    - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && {{ get_pip }} 'pip<=9.0.1'
+    # -c <() because of https://github.com/pypa/get-pip/issues/37
+    - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && {{ get_pip }} -c <(echo 'pip<=9.0.1')
     - cwd: /
     - reload_modules: True
     {%- if os != 'Fedora' %}
@@ -88,7 +89,8 @@ upgrade-installed-pip:
 {%- if pillar.get('py3', False) %}
 pip2-install:
   cmd.run:
-    - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && python2 get-pip.py 'pip<=9.0.1'
+    # -c <() because of https://github.com/pypa/get-pip/issues/37
+    - name: curl -L 'https://bootstrap.pypa.io/get-pip.py' -o get-pip.py && python2 get-pip.py -c <(echo 'pip<=9.0.1')
     - cwd: /
     - reload_modules: True
     {%- if os != 'Fedora' %}


### PR DESCRIPTION
`get-pip.py` is no longer working with just specifying a pip version on
the command line (see pypa/get-pip#37 ) so we have to do some shell
redirection for a constraints file. This will cause us to install pip
9.0.1 or less, as intended. It *should* work. This also modifies the
python 2 version.