### PR TITLE
Remove no_show_proc state

### DIFF
--- a/git/minimal.sls
+++ b/git/minimal.sls
@@ -40,7 +40,7 @@ include:
   - dpkg
   {%- endif %}
   {%- if grains['os'] not in ('Windows',) %}
-  - no_show_proc
+  # - no_show_proc
   - locale
   - gem
   - python.pip

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -77,7 +77,7 @@ include:
   - dpkg
   {%- endif %}
   {%- if grains['os'] not in ('Windows',) %}
-  - no_show_proc
+  # - no_show_proc
   - locale
   {%- endif %}
   {# On Windows (Jenkins builds) this is already installed but we may need this on other windows builds. #}


### PR DESCRIPTION
We are removing the NO_SHOW_PROC variable so we can see resource usage
on the centos7-py2 tests and figure out where those tests are running
long.