### PR TITLE
Add configuration files needed for using the auto-merge bot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Salt Jenkins Code Owners
+
+# See https://help.github.com/articles/about-codeowners/
+# for more info about the CODEOWNERS file
+
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# Default owners for everything in this repo
+*                       @Ch3LL @gtmanfred @rallytime
+

--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,19 @@
+# Configuration for probot-auto-merge - https://github.com/bobvanderlinden/probot-auto-merge
+
+# The minimum number of reviews from each association that approve the pull request before
+# doing an automatic merge. For more information about associations see:
+# https://developer.github.com/v4/reference/enum/commentauthorassociation/
+minApprovals:
+  OWNER: 1
+
+# The maximum number of reviews from each association that request changes to the pull request.
+# Setting this number higher than 0 will allow automatic merging while changes are still requested.
+# Requested changes from associations not defined in this list are ignored for automatic merging.
+maxRequestedChanges:
+  COLLABORATOR: 0
+
+# Blocking labels are the labels that can be attached to a pull request to make sure the pull request
+# is not being automatically merged.
+blockingLabels:
+  - Blocked
+


### PR DESCRIPTION
I want to see what (if anything) happens when this PR is submitted and whether or not this merge bot considers the results of the test run.

Details of this integration can be found here:
https://github.com/bobvanderlinden/probot-auto-merge

This adds me, @gtmanfred, and @Ch3LL as default CODEOWNERS to be be automatically requested as reviewers.

Then we set the minimum number of reviews (who must be OWNERS) to 1 for now.

We can override the auto merge by applying the `Blocked` label to any PR. This should be done _before_ submitting a PR approval by an owner since the minimum requirement is `1`.