### PR TITLE
Update travis file to allow arch failures and split ubuntu 16 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,16 @@ env:
     - SUITE=centos-6
     - SUITE=fedora
     - SUITE=ubuntu-14
-    - SUITE=ubuntu-16
+    - SUITE=py2-ubuntu-16
+    - SUITE=py3-ubuntu-16
     - SUITE=ubuntu-18
     - SUITE=debian-8
     - SUITE=debian-9
     - SUITE=opensuse
     - SUITE=arch
+matrix:
+  allow_failures:
+    - env: SUITE=arch
 bundler_args: --without windows
 script:
   # Setup for tests


### PR DESCRIPTION
The Ubuntu 16 build takes too long and often times out when running the py2 and py3 builds serially. This splits that build out into 2 slots so we don't fail on the travis timeout of 50 mins.

Arch is shuffled over to `allowed_failures` because there is a bug in salt right now that is fixed in 2017.7.8 - once that version is released, the arch build can be moved back.