### PR TITLE
Change the min number of approvals from OWNER to MEMBERS (2)

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -4,7 +4,7 @@
 # doing an automatic merge. For more information about associations see:
 # https://developer.github.com/v4/reference/enum/commentauthorassociation/
 minApprovals:
-  OWNER: 1
+  MEMBER: 2
 
 # The maximum number of reviews from each association that request changes to the pull request.
 # Setting this number higher than 0 will allow automatic merging while changes are still requested.


### PR DESCRIPTION
OWNER means the owner of the repo (so, saltstack) - not anything to do with team or contributor permissions.

Therefore, let's update this to `MEMBERS` and have 2 reviews required.

We can set some more restrictive permissions in the GH branch settings to require a CODEOWNER review.