### PR TITLE
Back-port some changes needed for auto-merge-bot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Salt Jenkins Code Owners
+
+# See https://help.github.com/articles/about-codeowners/
+# for more info about the CODEOWNERS file
+
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# Default owners for everything in this repo
+*                       @Ch3LL @gtmanfred @rallytime
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,16 @@ env:
     - SUITE=centos-6
     - SUITE=fedora
     - SUITE=ubuntu-14
-    - SUITE=ubuntu-16
+    - SUITE=py2-ubuntu-16
+    - SUITE=py3-ubuntu-16
     - SUITE=ubuntu-18
     - SUITE=debian-8
     - SUITE=debian-9
     - SUITE=opensuse
     - SUITE=arch
+matrix:
+  allow_failures:
+    - env: SUITE=arch
 bundler_args: --without windows
 script:
   # Setup for tests


### PR DESCRIPTION
The `CODEOWNERS` file is a convenience file that is needed in older branches in order for some of us to be notified when a PR needs our attention/review.

The travis file changes are needed in order to get all the tests to pass.

With 2 MEMBER approvals and the tests passing, [auto-merge-bot](https://github.com/bobvanderlinden/probot-auto-merge) will merge PRs automatically on older branches, too. 🎉 

