### PR TITLE
Changing the pypi proxy to the new AWS one

### DIFF
--- a/_states/pip2_state.py
+++ b/_states/pip2_state.py
@@ -52,7 +52,7 @@ def __virtual__():
 def installed(name, **kwargs):
     index_url = kwargs.pop('index_url', None)
     if index_url is None:
-        index_url = 'https://pypi.c7.saltstack.net/simple'
+        index_url = 'https://oss-nexus.aws.saltstack.net/repository/salt-proxy/simple'
     extra_index_url = kwargs.pop('extra_index_url', None)
     if extra_index_url is None:
         extra_index_url = 'https://pypi.python.org/simple'

--- a/_states/pip3_state.py
+++ b/_states/pip3_state.py
@@ -52,7 +52,7 @@ def __virtual__():
 def installed(name, **kwargs):
     index_url = kwargs.pop('index_url', None)
     if index_url is None:
-        index_url = 'https://pypi.c7.saltstack.net/simple'
+        index_url = 'https://oss-nexus.aws.saltstack.net/repository/salt-proxy/simple'
     extra_index_url = kwargs.pop('extra_index_url', None)
     if extra_index_url is None:
         extra_index_url = 'https://pypi.python.org/simple'

--- a/_states/pip_state.py
+++ b/_states/pip_state.py
@@ -45,7 +45,7 @@ def __virtual__():
 def installed(name, **kwargs):
     index_url = kwargs.pop('index_url', None)
     if index_url is None:
-        index_url = 'https://pypi.c7.saltstack.net/simple'
+        index_url = 'https://oss-nexus.aws.saltstack.net/repository/salt-proxy/simple'
     extra_index_url = kwargs.pop('extra_index_url', None)
     if extra_index_url is None:
         extra_index_url = 'https://pypi.python.org/simple'

--- a/python/junos-eznc.sls
+++ b/python/junos-eznc.sls
@@ -38,7 +38,7 @@ junos-eznc:
   pip.installed:
     - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
     - cwd: {{ salt['config.get']('pip_cwd', '') }}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://oss-nexus.aws.saltstack.net/repository/salt-proxy/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/jxmlease.sls
+++ b/python/jxmlease.sls
@@ -5,7 +5,7 @@ jxmlease:
   pip.installed:
     - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
     - cwd: {{ salt['config.get']('pip_cwd', '') }}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://oss-nexus.aws.saltstack.net/repository/salt-proxy/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install

--- a/python/paramiko.sls
+++ b/python/paramiko.sls
@@ -9,7 +9,7 @@ paramiko:
     - name: paramiko == 2.1.2
     - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
     - cwd: {{ salt['config.get']('pip_cwd', '') }}
-    - index_url: https://nexus.c7.saltstack.net/repository/salt-proxy/simple
+    - index_url: https://oss-nexus.aws.saltstack.net/repository/salt-proxy/simple
     - extra_index_url: https://pypi.python.org/simple
     - require:
       - cmd: pip-install


### PR DESCRIPTION
This will start using the AWS instance instead of the C7 one.

I have tested that the repo pulls without issues.
via pip.conf locally.
`[global]
index = https://oss-nexus.aws.saltstack.net/repository/salt-proxy 
index-url = https://oss-nexus.aws.saltstack.net/repository/salt-proxy/simple`


I hope that this eliminates the timeout issues we are seeing, as it will be local to the environment now.