### PR TITLE
Moving timelib download to new Nexus

### DIFF
--- a/python/timelib.sls
+++ b/python/timelib.sls
@@ -16,7 +16,7 @@ include:
 get-timelib-zip:
   archive.extracted:
     - name: {{ timelib_dir }}
-    - source: https://nexus.c7.saltstack.net/repository/salt-dev-raw/timelib-0.2.4-mac.zip
+    - source: https://oss-nexus.aws.saltstack.net/repository/salt-dev-raw/timelib-0.2.4-mac.zip
     - source_hash: sha512=0cb0b2f6a6249c38c8a5e043bcafde6f83f84d1d10f942d41dd8ff35f91df06b492811dbc896890a83c7feab17ba253c1517b93c9216a88e9e870e7465ac7a51
     - archive_format: zip
 


### PR DESCRIPTION
Added the last update for timelib.

And i just realized I synced but didn't create a branch. So travis may be mad.