### PR TITLE
Update PATH on macOSX after pip installed

### DIFF
--- a/python/pip.sls
+++ b/python/pip.sls
@@ -81,6 +81,14 @@ pip-install:
       {%- endif %}
     {%- endif %}
 
+{% if os_family == 'MacOS' %}
+pip_update_path:
+   environ.setenv:
+     - name: PATH
+     - value: '/opt/salt/bin/:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/salt/bin:/usr/local/sbin:$PATH'
+     - update_minion: True
+{% endif %}
+
 upgrade-installed-pip:
   pip.installed:
     - name: pip <=9.0.1
@@ -123,6 +131,14 @@ pip2-install:
     - reload_modules: True
     - require:
       - pkg: curl
+
+{% if os_family == 'MacOS' %}
+pip2_update_path:
+   environ.setenv:
+     - name: PATH
+     - value: '/opt/salt/bin/:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/salt/bin:/usr/local/sbin:$PATH'
+     - update_minion: True
+{% endif %}
 
 upgrade-installed-pip2:
   cmd.run:


### PR DESCRIPTION
After installing pip on macOSX sierra the PATH is being changed to user /usr/lib/bin/pip instead of /opt/salt/bin/pip. When these salt states are run the second time it works because we aren't installing pip, this will allow us to update the path to what we expect during the first initial salt-call run.