### PR TITLE
Don't install GitPython on Windows

### DIFF
--- a/python/gitpython.sls
+++ b/python/gitpython.sls
@@ -1,7 +1,6 @@
 {% if grains['os'] not in ('Windows',) %}
 include:
   - python.pip
-{% endif %}
 
 gitpython:
   pip.installed:
@@ -14,7 +13,6 @@ gitpython:
     {%- endif %}
     - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
     - cwd: {{ salt['config.get']('pip_cwd', '') }}
-{% if grains['os'] not in ('Windows',) %}
     - require:
       - cmd: pip-install
 {% endif %}


### PR DESCRIPTION
Use the version that gets installed with the powershell script,
currently at 2.1.3.

Reading file names that contain unicode characters on Windows is broken starting with GitPython 2.1.11
This is causing test failures in `unit.fileserver.test_gitfs.GitPythonTest`