### PR TITLE
Add npm binary symlink for macosx

### DIFF
--- a/git/salt.sls
+++ b/git/salt.sls
@@ -477,4 +477,14 @@ update-brew:
   cmd.run:
     - name: brew update
     - runas: jenkins
+
+node_binary:
+  file.symlink:
+    - name: /usr/bin/node
+    - target: /usr/local/bin/node
+
+npm_binary:
+  file.symlink:
+    - name: /usr/bin/npm
+    - target: /usr/local/bin/npm
 {%- endif %}


### PR DESCRIPTION
Currently on macosx when using `runas` argument with anything that calls `cmd.run` it uses the command `su -l <user> -c <cmd>`. According the man pages of su on macosx the PATH gets updated to only include `/bin/:/usr/bin/` and i dont believe this is an easy thing to change as I found this is grabbed from the _PATH_DEFPATH in the C paths.h file. So adding a binary symlink for npm.

This will fix the test failure: integration.states.test_npm.NpmStateTest.test_npm_install_url_referenced_package

Fixes: https://github.com/saltstack/salt-jenkins/issues/1141