### PR TITLE
Install latest apache-libcloud

### DIFF
--- a/python/libcloud.sls
+++ b/python/libcloud.sls
@@ -5,7 +5,7 @@ include:
 
 apache-libcloud:
   pip.installed:
-    - name: 'apache-libcloud==2.0.0'
+    - name: 'apache-libcloud'
     - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
     - cwd: {{ salt['config.get']('pip_cwd', '') }}
 {% if grains['os'] not in ('Windows',) %}


### PR DESCRIPTION
This test `integration.cloud.clouds.test_gce.GCETest.test_instance` is currently failing on deletion because of a bug in libcloud 2.0.0.  The error is `'GCENodeDriver' object has no attribute '_ex_populate_dict'\n"` which has been fixed. I tested that upgrading libcloud to `2.4.0` resolves the issue.