### PR TITLE
Adding Jinja json filter so that it doesn't get converted by repr()

### DIFF
--- a/cloud-test-configs/init.sls
+++ b/cloud-test-configs/init.sls
@@ -69,7 +69,7 @@ ec2-provider:
           id: {{ salt['pillar.get']('ec2:id', '') }}
           key: {{ salt['pillar.get']('ec2:key', '') }}
           keyname: {{ salt['pillar.get']('ec2:keyname', '') }}
-          securitygroupname: {{ salt['pillar.get']('ec2:securitygroup', '') }}
+          securitygroupname: {{ salt['pillar.get']('ec2:securitygroup', '') | json }}
           subnetid: {{ salt['pillar.get']('ec2:subnetid', '') }}
           ssh_interface: {{ salt['pillar.get']('ec2:ssh_interface', '') }}
           private_key: {{ salt['pillar.get']('ec2:private_key', '') }}


### PR DESCRIPTION
I have tested it on my system locally and it seemed to work.

It should work across all branches.

it was getting rendered as `securitygroupname: [u'testing-jenkins-prod']`

