### PR TITLE
Adding EC2 tags for the Kitchen configs

### DIFF
--- a/cloud-test-configs/init.sls
+++ b/cloud-test-configs/init.sls
@@ -92,6 +92,7 @@ ec2-profile:
           size: {{ salt['pillar.get']('ec2:size', '') }}
           sh_username: {{ salt['pillar.get']('ec2:user-centos7', '') }}
           script_args: '-P'
+          tag: {'created-by': 'cloud-tests'}
         ec2-win2012r2-test:
           provider: ec2-config
           size: {{ salt['pillar.get']('ec2:size', '') }}
@@ -105,6 +106,7 @@ ec2-profile:
           use_winrm: True
           winrm_verify_ssl: False
           deploy: True
+          tag: {'created-by': 'cloud-tests'}
         ec2-win2016-test:
           provider: ec2-config
           size: {{ salt['pillar.get']('ec2:size', '') }}
@@ -118,6 +120,7 @@ ec2-profile:
           use_winrm: True
           winrm_verify_ssl: False
           deploy: True
+          tag: {'created-by': 'cloud-tests'}
     - show_changes: False
     - require:
       - file: ssh-directory


### PR DESCRIPTION
Now the default test settings work, adding tags to salt-jenkins for kitchen.

When Jenkins runs, it will lay down the tag in the profile now. This should allow us to have a custom tag for the cleanup script to key off of. In case there are any aborted or left over instances, they will be cleaned up every 8 hours.