### PR TITLE
Add pypsexec for cloud tests

### DIFF
--- a/python/pypsexec.sls
+++ b/python/pypsexec.sls
@@ -1,0 +1,11 @@
+{% if grains['os'] in ('CentOS',) %}
+include:
+  - python.pip
+
+pypsexec:
+  pip.installed:
+    - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
+    - cwd: {{ salt['config.get']('pip_cwd', '') }}
+    - require:
+      - cmd: pip-install
+{% endif %}


### PR DESCRIPTION
Salt cloud will prefer pypsexec over winexe if it is installed.