### PR TITLE
Also install setuptools under git.minimal

### DIFF
--- a/git/minimal.sls
+++ b/git/minimal.sls
@@ -75,6 +75,7 @@ include:
   {#- Yes! openSuse ships xml as separate package #}
   - python.xml
   - python.hgtools
+  - python.setuptools
   - python.setuptools-scm
   - python-zypp
   - python.certifi


### PR DESCRIPTION
Required for salt-jenkins custom pip module and state module to work.