### PR TITLE
Fixing more-itertools dependency for CherryPy

### DIFF
--- a/git/minimal.sls
+++ b/git/minimal.sls
@@ -30,6 +30,7 @@ include:
   {%- if grains['os'] == 'MacOS' %}
   - python.path
   {% endif %}
+  - python.more-itertools
   # All VMs get docker-py so they can run unit tests
   {%- if grains['os'] == 'CentOS' and os_major_release == 7 %}
   # Docker integration tests only on CentOS 7 (for now)

--- a/git/salt.sls
+++ b/git/salt.sls
@@ -57,6 +57,7 @@ include:
   - man
   {%- endif %}
   - python.setuptools
+  - python.more-itertools
   {%- if grains['os'] == 'MacOS' %}
   - python.path
   {% endif %}

--- a/python/cherrypy.sls
+++ b/python/cherrypy.sls
@@ -13,11 +13,24 @@ cherrypy:
     {%- if salt['config.get']('pip_target', None)  %}
     - target: {{ salt['config.get']('pip_target') }}
     {%- endif %}
-{% if grains['os'] not in ('Windows',) %}
     - require:
-      - cmd: pip-install
-{% endif %}
+      - pip: more-itertools
 
+{%- if pillar.get('py3', False) %}
+{%- set itertools = 'more-itertools==6.0.0' %}
+{%- else %}
+{#- more-itertools 5.0.0 is the last version which supports Python 2.7 or 2x at all #}
+{%- set itertools = 'more-itertools==5.0.0' %}
+{%- endif %}
+
+more-itertools:
+  pip.installed:
+    - name: '{{ itertools }}'
+    - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
+    - cwd: {{ salt['config.get']('pip_cwd', '') }}
+    {%- if salt['config.get']('pip_target', None)  %}
+    - target: {{ salt['config.get']('pip_target') }}
+    {%- endif %}
 
 {% if on_py26 %}
 # Install older versions of CherryPy deps that have dropped Python 2.6 support

--- a/python/cherrypy.sls
+++ b/python/cherrypy.sls
@@ -1,6 +1,7 @@
 {% if grains['os'] not in ('Windows',) %}
 include:
   - python.pip
+  - python.more-itertools
 {% endif %}
 
 {% set on_py26 = True if grains.get('pythonexecutable', '').endswith('2.6') else False %}
@@ -13,24 +14,12 @@ cherrypy:
     {%- if salt['config.get']('pip_target', None)  %}
     - target: {{ salt['config.get']('pip_target') }}
     {%- endif %}
+{% if grains['os'] not in ('Windows',) %}
     - require:
+      - cmd: pip-install
       - pip: more-itertools
+{% endif %}
 
-{%- if pillar.get('py3', False) %}
-{%- set itertools = 'more-itertools==6.0.0' %}
-{%- else %}
-{#- more-itertools 5.0.0 is the last version which supports Python 2.7 or 2x at all #}
-{%- set itertools = 'more-itertools==5.0.0' %}
-{%- endif %}
-
-more-itertools:
-  pip.installed:
-    - name: '{{ itertools }}'
-    - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
-    - cwd: {{ salt['config.get']('pip_cwd', '') }}
-    {%- if salt['config.get']('pip_target', None)  %}
-    - target: {{ salt['config.get']('pip_target') }}
-    {%- endif %}
 
 {% if on_py26 %}
 # Install older versions of CherryPy deps that have dropped Python 2.6 support

--- a/python/more-itertools.sls
+++ b/python/more-itertools.sls
@@ -1,0 +1,15 @@
+{%- if pillar.get('py3', False) %}
+{%- set itertools = 'more-itertools==6.0.0' %}
+{%- else %}
+{#- more-itertools 5.0.0 is the last version which supports Python 2.7 or 2x at all #}
+{%- set itertools = 'more-itertools==5.0.0' %}
+{%- endif %}
+
+more-itertools:
+  pip.installed:
+    - name: '{{ itertools }}'
+    - bin_env: {{ salt['config.get']('virtualenv_path', '') }}
+    - cwd: {{ salt['config.get']('pip_cwd', '') }}
+    {%- if salt['config.get']('pip_target', None)  %}
+    - target: {{ salt['config.get']('pip_target') }}
+    {%- endif %}


### PR DESCRIPTION
This fixes the broken dependency that changes with more-itertools deprecating py2 in the latest version.