### PR TITLE
Work around bug in salt.ext.win_inet_pton

### DIFF
--- a/_modules/winrepo_bootstrap.py
+++ b/_modules/winrepo_bootstrap.py
@@ -78,3 +78,81 @@ def download_git_repos():
     if __salt__['winrepo.genrepo']():
         return ret
     return False
+
+
+#########################################################
+# Everything below here is only needed in 2017.7 branch #
+#########################################################
+import salt.ext.win_inet_pton
+import socket
+import ctypes
+import os
+import ipaddress
+import urllib3.util.ssl_
+
+
+class sockaddr(ctypes.Structure):
+    _fields_ = [("sa_family", ctypes.c_short),
+                ("__pad1", ctypes.c_ushort),
+                ("ipv4_addr", ctypes.c_byte * 4),
+                ("ipv6_addr", ctypes.c_byte * 16),
+                ("__pad2", ctypes.c_ulong)]
+
+if hasattr(ctypes, 'windll'):
+    WSAStringToAddressA = ctypes.windll.ws2_32.WSAStringToAddressA
+    WSAAddressToStringA = ctypes.windll.ws2_32.WSAAddressToStringA
+else:
+    def not_windows():
+        raise SystemError(
+            "Invalid platform. ctypes.windll must be available."
+        )
+    WSAStringToAddressA = not_windows
+    WSAAddressToStringA = not_windows
+
+def inet_pton(address_family, ip_string):
+    # Verify IP Address
+    # This will catch IP Addresses such as 10.1.2
+    if address_family == socket.AF_INET:
+        try:
+            if isinstance(ip_string, six.binary_type):
+                ipaddress.ip_address(six.text_type(ip_string))
+            else:
+                ipaddress.ip_address(ip_string)
+        except ValueError:
+            raise socket.error('illegal IP address string passed to inet_pton')
+        return socket.inet_aton(ip_string)
+
+    # Verify IP Address
+    # The `WSAStringToAddressA` function handles notations used by Berkeley
+    # software which includes 3 part IP Addresses such as `10.1.2`. That's why
+    # the above check is needed to enforce more strict IP Address validation as
+    # used by the `inet_pton` function in Unix.
+    # See the following:
+    # https://stackoverflow.com/a/29286098
+    # Docs for the `inet_addr` function on MSDN
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/ms738563.aspx
+    addr = sockaddr()
+    addr.sa_family = address_family
+    addr_size = ctypes.c_int(ctypes.sizeof(addr))
+
+    if WSAStringToAddressA(
+            ip_string.encode('ascii'),
+            address_family,
+            None,
+            ctypes.byref(addr),
+            ctypes.byref(addr_size)
+    ) != 0:
+        raise socket.error(ctypes.FormatError())
+
+    if address_family == socket.AF_INET:
+        return ctypes.string_at(addr.ipv4_addr, 4)
+    if address_family == socket.AF_INET6:
+        return ctypes.string_at(addr.ipv6_addr, 16)
+
+    raise socket.error('unknown address family')
+
+# Adding our two functions to the socket library
+if os.name == 'nt':
+    socket.inet_pton = inet_pton
+    salt.ext.win_inet_pton.inet_pton = inet_pton
+    urllib3.util.ssl_.inet_pton = inet_pton


### PR DESCRIPTION
This is only needed in 2017.7 because we're using 2017.7.8 to bootstrap
salt-jenkins.