### PR TITLE
[2018.3] Fixing six symlink in urllib3 location

### DIFF
--- a/python/six.sls
+++ b/python/six.sls
@@ -3,13 +3,22 @@ include:
   - python.pip
 {%- endif %}
 
-{#- Upgrading six on Fedora breaks urllib3 because of a symlink to six #}
-{%- if grains['os'] not in ('Fedora',) %}
 six:
   pip.installed:
     - upgrade: true
 {%- if grains['os'] not in ('Windows',) %}
     - require:
       - cmd: pip-install
+{%- endif %}
+
+{#- Upgrading six on Fedora breaks urllib3 because of a symlink to six #}
+{#- recreate the symlink under to point to new location #}
+{%- if grains['os'] in ('Fedora',) %}
+{%- set python_version = grains.get('pythonversion')[:2] %}
+{%- set urllib_six = "/usr/lib/python" + python_version[0]|string + "." + python_version[1]|string + "/site-packages/urllib3/packages/six.py" %}
+{%- if salt['file.is_link'](urllib_six) %}
+{{ urllib_six }}:
+  file.symlink:
+    - target: {{ "/usr/local/lib/python" + python_version[0]|string + "." + python_version[1]|string + "/site-packages/urllib3/packages/six.py" }}
 {%- endif %}
 {%- endif %}


### PR DESCRIPTION
Following an upgrade of the six python library on Fedora systems, the symlink found in the urllib3 install location is broken.  This change recreates it, pointing it to the right location under /usr/local/