### PR TITLE
 Change mysqld package name on Suse 15

### DIFF
--- a/python/mysqldb.sls
+++ b/python/mysqldb.sls
@@ -7,10 +7,12 @@
     {%- set mysqldb = 'MySQL-python' %}
   {%- endif %}
 {%- elif grains['os_family'] == 'Suse' %}
-  {%- set mysqldb = 'python2-PyMySQL' %}
-  {%- if pillar.get('py3', False) %}
-      {%- set mysqldb = 'python3-PyMySQL' %}
-  {%- endif %}
+  {%- if grains['osmajorrelease'] == '15' %}
+      {%- set mysqldb = 'python2-PyMySQL' %}
+      {%- if pillar.get('py3', False) %}
+          {%- set mysqldb = 'python3-PyMySQL' %}
+      {%- endif %}
+  {% endif %}
 {%- elif grains['os_family'] == 'FreeBSD' %}
   {%- set mysqldb = 'py27-MySQLdb' %}
 {%- else %}

--- a/python/mysqldb.sls
+++ b/python/mysqldb.sls
@@ -13,7 +13,7 @@
       {%- if pillar.get('py3', False) %}
           {%- set mysqldb = 'python3-PyMySQL' %}
       {%- endif %}
-  {% endif %}
+  {%- endif %}
 {%- elif grains['os_family'] == 'FreeBSD' %}
   {%- set mysqldb = 'py27-MySQLdb' %}
 {%- else %}

--- a/python/mysqldb.sls
+++ b/python/mysqldb.sls
@@ -7,6 +7,7 @@
     {%- set mysqldb = 'MySQL-python' %}
   {%- endif %}
 {%- elif grains['os_family'] == 'Suse' %}
+  {%- set mysqldb = 'python-MySQL-python' %}
   {%- if grains['osmajorrelease'] == '15' %}
       {%- set mysqldb = 'python2-PyMySQL' %}
       {%- if pillar.get('py3', False) %}

--- a/python/mysqldb.sls
+++ b/python/mysqldb.sls
@@ -7,7 +7,10 @@
     {%- set mysqldb = 'MySQL-python' %}
   {%- endif %}
 {%- elif grains['os_family'] == 'Suse' %}
-  {%- set mysqldb = 'python-MySQL-python' %}
+  {%- set mysqldb = 'python2-PyMySQL' %}
+  {%- if pillar.get('py3', False) %}
+      {%- set mysqldb = 'python3-PyMySQL' %}
+  {%- endif %}
 {%- elif grains['os_family'] == 'FreeBSD' %}
   {%- set mysqldb = 'py27-MySQLdb' %}
 {%- else %}


### PR DESCRIPTION
The mysqld package on Suse 15 is named `<python_ver>-PyMySQL`

Should fix part of https://github.com/saltstack/salt/issues/51890