### PR TITLE
Do not add fetch_libzmq opt for pyzmq install on suse

### DIFF
--- a/python/pyzmq.sls
+++ b/python/pyzmq.sls
@@ -18,8 +18,10 @@ pyzmq:
 
   pip.installed:
     - name: pyzmq{{salt.pillar.get('pyzmq:version', '')}}
+  {%- if grains['os_family'] not in ('Suse') %}
     - global_options:
       - fetch_libzmq
+  {% endif %}
     - install_options:
       - --zmq=bundled
     {%- if grains['os'] != 'Windows' %}


### PR DESCRIPTION
When you install pyzmq's pip package with the global option `fetch_libzmq` this error appears:

```
ip-10-27-14-49:~ # python3 -c "import zmq"
/usr/lib64/python3.4/site-packages/zmq/backend/cffi/__pycache__/_cffi_ext.c:216:17: fatal error: zmq.h: No such file or directory
 #include <zmq.h>
                 ^
compilation terminated.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib64/python3.4/site-packages/zmq/__init__.py", line 47, in <module>
    from zmq import backend
  File "/usr/lib64/python3.4/site-packages/zmq/backend/__init__.py", line 40, in <module>
    reraise(*exc_info)
  File "/usr/lib64/python3.4/site-packages/zmq/utils/sixcerpt.py", line 34, in reraise
    raise value
  File "/usr/lib64/python3.4/site-packages/zmq/backend/__init__.py", line 27, in <module>
    _ns = select_backend(first)
  File "/usr/lib64/python3.4/site-packages/zmq/backend/select.py", line 28, in select_backend
    mod = __import__(name, fromlist=public_api)
  File "/usr/lib64/python3.4/site-packages/zmq/backend/cython/__init__.py", line 6, in <module>
    from . import (constants, error, message, context,
ImportError: /usr/lib64/python3.4/site-packages/zmq/backend/cython/error.cpython-34m.so: undefined symbol: zmq_strerror
```

removing this global option installs pyzmq properly on suse


Helps fix:  https://github.com/saltstack/salt/issues/51890