### PR TITLE
[2018.3] Merge forward from 2017.7

### DIFF
--- a/git/minimal.sls
+++ b/git/minimal.sls
@@ -63,8 +63,10 @@ include:
   - sed
   {%- endif %}
   {%- if grains['os'] not in ('MacOS', 'Windows') %}
-  {%- if grains['os'] != 'CentOS' or (grains['os'] == 'CentOS' and os_major_release > 6) %} {#- Don't install python-ldap on CentOS 6 #}
-  - python.ldap  {#- Installing python-ldap using pip since it needs system deps, let's do it all here for now #}
+  {%- if grains['os_family'] in ('Arch', 'Debian', 'Suse', 'RedHat') %}
+    {%- if grains['os'] != 'CentOS' or (grains['os'] == 'CentOS' and os_major_release > 6) %} {#- Don't install openldap on CentOS 6 #}
+  - openldap
+    {%- endif %}
   {%- endif %}
   - dnsutils
   - rsync

--- a/openldap.sls
+++ b/openldap.sls
@@ -1,0 +1,22 @@
+{%- load_yaml as map %}
+Debian:
+  pkgs:
+  - libldap2-dev
+  - libsasl2-dev
+  - libdpkg-perl
+RedHat:
+  pkgs:
+  - openldap-devel
+Suse:
+  pkgs:
+  - openldap2-devel
+  - cyrus-sasl-devel
+Arch:
+  pkgs:
+  - openldap
+{%- endload %}
+{%- set openldap = salt['grains.filter_by'](map, grain='os_family') %}
+
+openldap:
+  pkg.installed:
+    - pkgs: {{openldap.pkgs}}


### PR DESCRIPTION
Additional, install openldap instead of python-ldap for minimal installs