### PR TITLE
[2017.7] Arch and Amazon Linux 1 Fixes

### DIFF
--- a/locale.sls
+++ b/locale.sls
@@ -41,10 +41,12 @@ accept_LANG_sshd:
   file.append:
     - name: /etc/ssh/sshd_config
     - text: AcceptEnv LANG
+  {%- if not pillar.get('packer_golden_images_build', False) %}
   service.running:
     - name: sshd
     - listen:
       - file: accept_LANG_sshd
+  {%- endif %}
 {%- endif %}
 
 us_locale:

--- a/python/docker.sls
+++ b/python/docker.sls
@@ -1,7 +1,7 @@
 {%- if grains['os'] == 'Windows' %}
   {%- set docker = 'docker==2.7.0' %}
 {%- else %}
-  {%- set docker = 'docker' %}
+  {%- set docker = 'docker==3.7.2' %}
 {%- endif %}
 
 include:

--- a/python/nox.sls
+++ b/python/nox.sls
@@ -1,4 +1,12 @@
+{%- set os_family = salt['grains.get']('os_family', '') %}
+{%- set os_major_release = salt['grains.get']('osmajorrelease', 0)|int %}
 {%- set nox_version = '2018.10.17' %}
+
+{%- if os_family == 'RedHat' and os_major_release == 2018 %}
+  {%- set on_amazonlinux_1 = True %}
+{%- else %}
+  {%- set on_amazonlinux_1 = False %}
+{%- endif %}
 
 include:
   - python.pip
@@ -12,6 +20,10 @@ nox:
     {%- else %}
     - onlyif:
       - '[ "$(which nox 2>/dev/null)" = "" ]'
+    {%- endif %}
+    {%- if on_amazonlinux_1 %}
+    - install_options:
+      - --prefix=/usr
     {%- endif %}
     - require:
       - pip-install


### PR DESCRIPTION
*  Don't worry about sshd running on packer golden images
*  Install `nox` under the `/usr` prefix on Amazon Linux 1 