### PR TITLE
 Specify docker-py version for centos 

### DIFF
--- a/python/docker.sls
+++ b/python/docker.sls
@@ -1,5 +1,7 @@
 {%- if grains['os'] == 'Windows' %}
   {%- set docker = 'docker==2.7.0' %}
+{%- elif grains['os'] == 'CentOS' and salt['grains.get']('osmajorrelease', 0) == 7 %}
+  {%- set docker = 'docker<4.0.0' %}
 {%- else %}
   {%- set docker = 'docker' %}
 {%- endif %}

--- a/python/docker.sls
+++ b/python/docker.sls
@@ -1,6 +1,6 @@
 {%- if grains['os'] == 'Windows' %}
   {%- set docker = 'docker==2.7.0' %}
-{%- elif grains['os'] == 'CentOS' and salt['grains.get']('osmajorrelease', 0) == 7 %}
+{%- elif grains['os'] == 'CentOS' and grains['osmajorrelease'] == 7 %}
   {%- set docker = 'docker<4.0.0' %}
 {%- else %}
   {%- set docker = 'docker' %}


### PR DESCRIPTION
The centos-7 VM is not bootstrapping correctly for cloud tests here: https://jenkinsci.saltstack.com/job/2019.2.1/view/Cloud/job/salt-centos-7-py3-cloud/51/consoleFull

due to this error:

```
13:36:55        ----------
13:36:55                  ID: docker_py
13:36:55            Function: pip.installed
13:36:55                Name: docker
13:36:55              Result: False
13:36:55             Comment: Failed to install packages: docker. Error: Collecting docker
13:36:55                 Downloading https://oss-nexus.aws.saltstack.net/repository/salt-proxy/packages/91/93/310fe092039f6b0759a1f8524e9e2c56f8012804fa2a8da4e4289bb74d7c/docker-4.0.1-py2.py3-none-any.whl (138kB) docker requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*' but the running Python is 3.4.10
13:36:55               You are using pip version 9.0.1, however version 19.1.1 is available.
13:36:55               You should consider upgrading via the 'pip install --upgrade pip' command.
13:36:55             Started: 17:31:30.274572
13:36:55            Duration: 1106.746 ms
13:36:55             Changes:   
13:36:55        ----------
```

this is because in docker py 4.0.0 they dropped support for python3.4 which is the version of python 3 we test on centos-7.

ping @s0undt3ch i'm not sure why we aren't using nox on the cloud tests yet, but i figured i can get this in for now and i also see it failing on other branches where we do not have nox so i'll cherry-pick it to those branches as well once merged as a temporary fix

Fixes https://github.com/saltstack/salt/issues/53168