### PR TITLE
Junos fix

### DIFF
--- a/python/junos-eznc.sls
+++ b/python/junos-eznc.sls
@@ -8,6 +8,7 @@ include:
   {%- if include_paramiko %}
   - python.paramiko
   {%- endif %}
+  - python.ncclient
 
 {%- if grains['os'] in ['Ubuntu', 'Debian'] %}
 pyez dependencies:
@@ -41,3 +42,4 @@ junos-eznc:
       {%- if include_paramiko %}
       - pip: paramiko
       {%- endif %}
+      - pip: ncclient

--- a/python/ncclient.sls
+++ b/python/ncclient.sls
@@ -1,0 +1,11 @@
+include:
+  - python.pip
+
+# Newer versions of paramiko (2.2.0) require a minimum version of the
+# PyNaCl lib of 1.0.1, which doesn't install correctly on some distros.
+# This is pinned at 2.1.2 until the installation issues are resolved.
+ncclient:
+  pip.installed:
+    - name: ncclient==0.6.4
+    - require:
+      - cmd: pip-install

--- a/python/ncclient.sls
+++ b/python/ncclient.sls
@@ -1,9 +1,8 @@
 include:
   - python.pip
 
-# Newer versions of paramiko (2.2.0) require a minimum version of the
-# PyNaCl lib of 1.0.1, which doesn't install correctly on some distros.
-# This is pinned at 2.1.2 until the installation issues are resolved.
+# ncclient 0.6.5 fails to install, we should be able to remove this after that
+# issue is resolved
 ncclient:
   pip.installed:
     - name: ncclient==0.6.4


### PR DESCRIPTION
ncclient 0.6.5 fails to install, we should be able to remove this after that issue is resolved.