### PR TITLE
Update root certs on the golden images (2019.2)

### DIFF
--- a/windows/ca_roots.sls
+++ b/windows/ca_roots.sls
@@ -1,0 +1,10 @@
+download_ca_roots_from_windows_update:
+  cmd.run:
+    - name: certutil -generateSSTFromWU %temp%\roots.sst
+
+update_ca_roots_store:
+  cmd.run:
+    - name: (Get-ChildItem -Path $env:Temp\roots.sst) | Import-Certificate -CertStoreLocation Cert:\LocalMachine\Root
+    - shell: powershell
+    - require:
+      - download_ca_roots_from_windows_update

--- a/windows/init.sls
+++ b/windows/init.sls
@@ -9,6 +9,7 @@ include:
   {%- endif %}
   - windows.git
   - windows.nsis
+  - windows.ca_roots
   - windows.compiler
   - windows.vcredist
   - windows.openssl


### PR DESCRIPTION
Update root certificate store on Windows. This fixes some issues with downloading files from 3rd party sites.
Required for zcbuildout tests: https://github.com/saltstack/salt/pull/54082