### PR TITLE
Create a vm from valid vultr size

### DIFF
--- a/cloud-test-configs/init.sls
+++ b/cloud-test-configs/init.sls
@@ -282,7 +282,7 @@ vultr-profile:
     - contents: |
         vultr-test:
           provider: vultr-config
-          size: 2048 MB RAM,40 GB SSD,2.00 TB BW
+          size: 2048 MB RAM,64 GB SSD,2.00 TB BW
           image: CentOS 7 x64
           enable_private_network: False
           location: New Jersey


### PR DESCRIPTION
Use a valid vultr size

``` [ERROR   ] Vultr does not have a size with id or name 2048 MB RAM,40 GB SSD,2.00 TB BW```
