### PR TITLE
[WIP] DO NOT MERGE - Test python3.7 on windows

### DIFF
--- a/python3.sls
+++ b/python3.sls
@@ -52,7 +52,7 @@ python3:
     {%- else %}
     - aggregate: False
     {%- if grains['os'] == 'Windows' %}
-    - version: '3.6.8150.0'
+    - version: '3.7.4150.0'
     {%- else %}
     - version: '3.5.4150.0'
     {%- endif %}

--- a/python3.sls
+++ b/python3.sls
@@ -51,7 +51,11 @@ python3:
     - aggregate: True
     {%- else %}
     - aggregate: False
+    {%- if grains['os'] == 'Windows' %}
+    - version: '3.6.8150.0'
+    {%- else %}
     - version: '3.5.4150.0'
+    {%- endif %}
     - extra_install_flags: "TargetDir=C:\\Python35 Include_doc=0 Include_tcltk=0 Include_test=0 Include_launcher=1 PrependPath=1 Shortcuts=0"
     - require:
       - win-pkg-refresh


### PR DESCRIPTION
Just a test to see if python3.7 upgrade fixes virtualenv test failure. 

What I found is the test `integration.states.test_pip_state.PipStateTest.test_issue_6912_wrong_owner` was failing with python3.5 and virtualenv >=16.7.8. 

On our current images its passing because we are using 16.7.7. The commit that caused the issue is here https://github.com/pypa/virtualenv/pull/1450/files#diff-7e83770aa980bd4327db90f4eafeffdfR993

This new commit ensured that the most recent version of the pip wheel in `virtualenv_support` directory. There are two pip versions in the `virtualenv_support` directory -> 19.1.1 and 19.3.1. I see the issue when 19.3.1 is used instead of 19.1.1.

I'm still tracking down why `19.3.1` pip library is causing the test to fail, but I did test with python3.6 and it did pass, so i want to see if that is the case in this PR as well.

Tests wont pass until after https://github.com/saltstack/salt-jenkins/pull/1630 is merged