### PR TITLE
Include all dependencies for pycurl in debian OSs

### DIFF
--- a/state-tree/libcurl.sls
+++ b/state-tree/libcurl.sls
@@ -1,11 +1,15 @@
-{%- set libcurl_pkg = 'libcurl-devel' %}
+{%- set libcurl_pkg = ['libcurl-devel'] %}
 {%- if grains['os_family'] == 'Debian' %}
-  {%- set libcurl_pkg = 'libcurl4-openssl-dev' %}
+  {%- set libcurl_pkg = ['libcurl4-openssl-dev', 'libssl-dev', 'libgnutls28-dev'] %}
 {%- endif %}
 
 # Arch ships libcurl dev files with the curl package
 {%- if grains['os_family'] not in ('Arch',) %}
-{{ libcurl_pkg }}:
+libcurl_and_pycurl_deps:
   pkg.latest:
     - aggregate: True
+    - pkgs:
+  {%- for pkg in libcurl_pkg %}
+      - {{ pkg }}
+  {%- endfor %}
 {%- endif %}


### PR DESCRIPTION
The install of pycurl is failing on debian OSs on this PR: https://github.com/saltstack/salt/pull/55831

```
17:15:57             x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DPYCURL_VERSION="7.43.0.5" -DHAVE_CURL_SSL=1 -DHAVE_CURL_GNUTLS=1 -DHAVE_CURL_SSL=1 -I/tmp/kitchen/testing/.nox/runtests-parametrized-3-crypto-none-transport-zeromq-coverage-true/include -I/usr/include/python3.6m -c src/docstrings.c -o build/temp.linux-x86_64-3.6/src/docstrings.o
17:15:57             In file included from src/docstrings.c:4:0:
17:15:57             src/pycurl.h:191:13: fatal error: gnutls/gnutls.h: No such file or directory
17:15:57              #   include <gnutls/gnutls.h>
17:15:57                   ^~~~~~~~~~~~~~~~~
17:15:57             compilation terminated.
17:15:57             error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```

There are a couple more dependencies that need to be installed.