### PR TITLE
update windows to optionally install unix commands from git for windows

### DIFF
--- a/state-tree/windows/git.sls
+++ b/state-tree/windows/git.sls
@@ -9,6 +9,7 @@ git-windeps:
     - name: git
     - version: 2.22.0
     - refresh_modules: True
+    - extra_install_flags: "/GitAndUnixToolsOnPath"
     - require:
       - git-exists-in-path
   {%- else %}


### PR DESCRIPTION
The git for windows installer allows users to optionally download and install unix commands, some of which will be used for windows features inside salt.