### PR TITLE
Fix CentOS7 container: Export en_US.utf8 for LANG on CentOS7

### DIFF
--- a/os-images/files/install-salt.sh
+++ b/os-images/files/install-salt.sh
@@ -8,8 +8,19 @@ set -x
 # Check if in container
 # https://stackoverflow.com/questions/52065842/python-docker-ascii-codec-cant-encode-character
 if [ -f /.dockerenv ]; then
-    echo "Running in container. Updating env var: LANG=C.UTF-8"
-    export LANG=C.UTF-8
+    echo "Running in container!"
+    CURRENT_OS=$(cat /etc/*ease* | egrep '^NAME=|^VERSION=')
+    IS_CENTOS7=$(echo $CURRENT_OS | grep CentOS | grep 7)
+    if [[ -z $IS_CENTOS7 ]]; then
+        echo "Container is NOT running CentOS 7."
+        echo "Updating env var: C.UTF-8"
+        export LANG=C.UTF-8
+    else
+        # CentOS7 doesn't have C.UTF-8; must use en_US.utf8
+        echo "Container IS running CentOS 7."
+        echo "Updating env var: LANG=en_US.utf8"
+        export LANG=en_US.utf8
+    fi
 fi
 
 export PATH="~/.pyenv/bin:$PATH"

--- a/os-images/files/install-salt.sh
+++ b/os-images/files/install-salt.sh
@@ -9,7 +9,7 @@ set -x
 # https://stackoverflow.com/questions/52065842/python-docker-ascii-codec-cant-encode-character
 if [ -f /.dockerenv ]; then
     echo "Running in container!"
-    IS_CENTOS7=$(echo $(cat /etc/*ease* | grep '^NAME=\|^VERSION=') | grep CentOS | grep 7)
+    IS_CENTOS7=$(echo $(cat /etc/*ease* | grep '^NAME=\|^VERSION=') | grep CentOS | grep 7 || true)
     if [[ -z $IS_CENTOS7 ]]; then
         echo "Container is NOT running CentOS 7."
         echo "Updating env var: C.UTF-8"

--- a/os-images/files/install-salt.sh
+++ b/os-images/files/install-salt.sh
@@ -9,8 +9,7 @@ set -x
 # https://stackoverflow.com/questions/52065842/python-docker-ascii-codec-cant-encode-character
 if [ -f /.dockerenv ]; then
     echo "Running in container!"
-    CURRENT_OS=$(cat /etc/*ease* | egrep '^NAME=|^VERSION=')
-    IS_CENTOS7=$(echo $CURRENT_OS | grep CentOS | grep 7)
+    IS_CENTOS7=$(echo $(cat /etc/*ease* | grep '^NAME=\|^VERSION=') | grep CentOS | grep 7)
     if [[ -z $IS_CENTOS7 ]]; then
         echo "Container is NOT running CentOS 7."
         echo "Updating env var: C.UTF-8"


### PR DESCRIPTION
Installing `salt` is failing on CentOS 7 containers. This should fix it.

```bash
# Tested in local container within:
# docker container run --rm -it centos:7 /bin/bash
if [ -f /.dockerenv ]; then
    echo "Running in container"
    IS_CENTOS7=$(echo $(cat /etc/*ease* | grep '^NAME=\|^VERSION=') | grep CentOS | grep 7 || true)
    if [[ -z $IS_CENTOS7 ]]; then
        echo "Container is NOT running CentOS 7."
        echo "Updating env var: C.UTF-8"
        export LANG=C.UTF-8
    else
        # CentOS7 doesn't have C.UTF-8; must use en_US.utf8
        echo "Container IS running CentOS 7."
        echo "Updating env var: LANG=en_US.utf8"
        export LANG=en_US.utf8
    fi
fi
    
yum install -y gcc zlib-devel bzip2 bzip2-devel \
    readline-devel sqlite sqlite-devel openssl-devel \
    tk-devel libffi-devel xz-devel curl git make

# Install pyenv
BASHRC='/root/.bashrc'
touch $BASHRC
curl https://pyenv.run | bash
{
  echo
  echo export PATH="/root/.pyenv/bin:\${PATH}"
  echo eval '"'"\$(pyenv init --path)"'"'
  echo eval '"'"\$(pyenv init -)"'"'
  echo eval '"'"\$(pyenv virtualenv-init -)"'"'
  echo
} >>"${BASHRC}"
source /root/.bashrc

# Build Python 3.6.13
pyenv install 3.6.13

# Install salt
pyenv shell 3.6.13
pip install salt==3002.2
```