### PR TITLE
update Path variable for windows to use unix commands

### DIFF
--- a/state-tree/windows/git.sls
+++ b/state-tree/windows/git.sls
@@ -3,6 +3,10 @@ git-exists-in-path:
   win_path.exists:
     - name: 'C:\Program Files\Git\cmd'
 
+git-exists-in-path-unix:
+  win_path.exists:
+    - name: 'C:\Program Files\Git\usr\bin'
+
 git-windeps:
   {%- if not git_binary %}
   pkg.installed:
@@ -12,6 +16,7 @@ git-windeps:
     - extra_install_flags: "/GitAndUnixToolsOnPath"
     - require:
       - git-exists-in-path
+      - git-exists-in-path-unix
   {%- else %}
   test.show_notification:
     - text: "Git is already installed"


### PR DESCRIPTION
Fixes: https://github.com/saltstack/salt/pull/60399

This PR adds C:\Program Files\Git\usr\bin to the env path.