### PR TITLE
Changes to Photon OS image

### DIFF
--- a/os-images/AWS/photon/photon.json
+++ b/os-images/AWS/photon/photon.json
@@ -87,6 +87,8 @@
         "tdnf update -y",
         "if ! grep -q fips=1 /boot/systemd.cfg; then sed -i 's/^systemd_cmdline=.*/& fips=1/' /boot/systemd.cfg; fi",
         "if ! grep -q 'FipsMode yes' /etc/ssh/sshd_config; then echo 'FipsMode yes' >> /etc/ssh/sshd_config; fi",
+        "echo alias rsync='rsync -zz' >> /root/.profile",
+        "echo umask 022 >> /root/.profile",
         "reboot"
       ],
       "expect_disconnect": true,


### PR DESCRIPTION
Adding some additional commands for the Photon OS images, need to alias rsync to rsync -zz because the --compress flag has been removed.  Also need to set the default umask to 022 to ensure permissions are correct for files and directories, to ensure tests pass.