### PR TITLE
Add make to linux platforms we test packages

### DIFF
--- a/golden-state-tree/os/amazon/pkgs/init.sls
+++ b/golden-state-tree/os/amazon/pkgs/init.sls
@@ -10,6 +10,7 @@ include:
   - pkgs.libsodium
   - pkgs.libxml
   - pkgs.libxslt
+  - pkgs.make
   - pkgs.man
   - pkgs.nginx
   - pkgs.openldap

--- a/golden-state-tree/os/centos-stream/pkgs/init.sls
+++ b/golden-state-tree/os/centos-stream/pkgs/init.sls
@@ -13,6 +13,7 @@ include:
   - pkgs.libsodium
   - pkgs.libxml
   - pkgs.libxslt
+  - pkgs.make
   - pkgs.man
   - pkgs.nginx
   - pkgs.openldap

--- a/golden-state-tree/os/centos/pkgs/init.sls
+++ b/golden-state-tree/os/centos/pkgs/init.sls
@@ -14,6 +14,7 @@ include:
   - pkgs.libsodium
   - pkgs.libxml
   - pkgs.libxslt
+  - pkgs.make
   - pkgs.man
   - pkgs.nginx
   - pkgs.openldap

--- a/golden-state-tree/os/debian/pkgs/init.sls
+++ b/golden-state-tree/os/debian/pkgs/init.sls
@@ -12,6 +12,7 @@ include:
   - pkgs.libsodium
   - pkgs.libxml
   - pkgs.libxslt
+  - pkgs.make
   - pkgs.man
   - pkgs.nginx
   - pkgs.openldap

--- a/golden-state-tree/os/ubuntu/pkgs/init.sls
+++ b/golden-state-tree/os/ubuntu/pkgs/init.sls
@@ -17,6 +17,7 @@ include:
   - pkgs.libxml
   - pkgs.libxslt
   - pkgs.lxc
+  - pkgs.make
   - pkgs.man
   - pkgs.nginx
   - pkgs.npm

--- a/golden-state-tree/pkgs/make.sls
+++ b/golden-state-tree/pkgs/make.sls
@@ -1,2 +1,2 @@
 make:
-  pkg.installed:
+  pkg.installed

--- a/golden-state-tree/pkgs/make.sls
+++ b/golden-state-tree/pkgs/make.sls
@@ -1,0 +1,2 @@
+make:
+  pkg.installed:


### PR DESCRIPTION
PyGithub requires `make` to install the pip package. We are testing installing this in our package tests.