### PR TITLE
Adding Debian 12 golden images, and fixing ArchLinux

### DIFF
--- a/golden-state-tree/python-pkgs/nox.sls
+++ b/golden-state-tree/python-pkgs/nox.sls
@@ -45,7 +45,11 @@
 nox:
   cmd.run:
   {%- if not on_windows %}
+    {%- if grains['osfinger'] == 'Debian-12' %}
+    - name: "{{ pip }} install 'nox=={{ nox_version }}' --break-system-packages"
+    {%- else %}
     - name: "{{ pip }} install 'nox=={{ nox_version }}'"
+    {%- endif %}
   {%- else %}
     - name: {{ pip }} install nox=={{ nox_version }}
   {%- endif %}

--- a/golden-state-tree/python-pkgs/nox.sls
+++ b/golden-state-tree/python-pkgs/nox.sls
@@ -45,7 +45,7 @@
 nox:
   cmd.run:
   {%- if not on_windows %}
-    {%- if grains['os'] == 'Debian' and grains['osmajorrelease'] == '12' %}
+    {%- if (grains['os'] == 'Debian' and grains['osmajorrelease'] >= 12) or grains['os'] == 'Arch' %}
     - name: "{{ pip }} install 'nox=={{ nox_version }}' --break-system-packages"
     {%- else %}
     - name: "{{ pip }} install 'nox=={{ nox_version }}'"

--- a/golden-state-tree/python-pkgs/nox.sls
+++ b/golden-state-tree/python-pkgs/nox.sls
@@ -45,7 +45,7 @@
 nox:
   cmd.run:
   {%- if not on_windows %}
-    {%- if grains['osfinger'] == 'Debian-12' %}
+    {%- if grains['os'] == 'Debian' and grains['osmajorrelease'] == '12' %}
     - name: "{{ pip }} install 'nox=={{ nox_version }}' --break-system-packages"
     {%- else %}
     - name: "{{ pip }} install 'nox=={{ nox_version }}'"

--- a/os-images/AWS/debian/debian-12-arm64.pkrvars.hcl
+++ b/os-images/AWS/debian/debian-12-arm64.pkrvars.hcl
@@ -1,0 +1,2 @@
+ami_filter    = "debian-12-arm64*"
+instance_type = "m6g.large"

--- a/os-images/AWS/debian/debian-12-x86_64.pkrvars.hcl
+++ b/os-images/AWS/debian/debian-12-x86_64.pkrvars.hcl
@@ -1,0 +1,2 @@
+ami_filter    = "debian-12-amd64*"
+instance_type = "t3a.large"


### PR DESCRIPTION
There are two paths to getting `nox` on Debian 12:

- Install it via `pip3` but with `--break-system-packages`, since operating systems are moving toward avoiding installing any Python packages at the system level (due to the risk of breaking OS functionality).

OR:

- Install `nox` via `apt install python3-nox nox -y` (or `pkg.install` with a more complicated state jinja logic), but not be using the targeted, expected version of `nox` referenced in `nox.sls` to be used (`python3-nox` is currently `2022.11.21`)

Using `--break-system-packages` seems to be the exact same experience currently used by all other AMIs.

From a long-term perspective, we should evaluate whether we will want to run `nox` from one of the following:

- System level Python env, which means requiring `--break-system-packages` as more OS targets require it (currently how this is implemented on systems, and what this current draft PR is implementing with passing tests)
- Provide `nox` via a different, isolated virtualenv/venv (created by the system-level Python version)
- Provide `nox` via a different, isolated pyenv virtualenv (under a standardized Python version)