### PR TITLE
Fix SUSE Leap 15 builds: node v18 and python3-xml fixes

### DIFF
--- a/golden-state-tree/os/suse/pkgs/python-xml.sls
+++ b/golden-state-tree/os/suse/pkgs/python-xml.sls
@@ -1,2 +1,3 @@
-python-xml:
+# python3-xml is included in python3-base
+python3-base:
   pkg.installed

--- a/golden-state-tree/pkgs/npm.sls
+++ b/golden-state-tree/pkgs/npm.sls
@@ -6,8 +6,8 @@
 
 # Suse does not package npm separately
 {%- if suse %}
-  {%- set npm = 'npm16' %}
-  {%- set nodejs = 'nodejs16' %}
+  {%- set npm = 'npm18' %}
+  {%- set nodejs = 'nodejs18' %}
 {%- elif ubuntu %}
   {%- set npm = 'npm' %}
   {%- set nodejs = 'nodejs' %}


### PR DESCRIPTION
- Upgrade node to v18 since v16 no longer directly installable (v18 is new LTS)
- `python-xml` / `python3-xml` is now provided as part of `python3-base` installs

This should fix SUSE builds of AMIs.