### PR TITLE
Install cron on Debian

### DIFF
--- a/golden-state-tree/os/debian/pkgs/init.sls
+++ b/golden-state-tree/os/debian/pkgs/init.sls
@@ -1,4 +1,5 @@
 include:
+  - pkgs.cron
   - pkgs.curl
   - pkgs.dmidecode
   - pkgs.dnsutils

--- a/golden-state-tree/pkgs/cron.sls
+++ b/golden-state-tree/pkgs/cron.sls
@@ -1,2 +1,7 @@
+{%- if grains['os'] == 'Debian' %}
+cron:
+  pkg.installed
+{%- else %}
 cronie:
   pkg.installed
+{%- endif %}


### PR DESCRIPTION
`cron` is required, and isn't included by default on Debian 12.

This PR is required for generated an updated AMI so tests pass on:
- https://github.com/saltstack/salt/pull/65116