### PR TITLE
Add Ubuntu 23.04; Add official Canonical owner ID

### DIFF
--- a/golden-state-tree/config/sshd_config.sls
+++ b/golden-state-tree/config/sshd_config.sls
@@ -39,7 +39,11 @@ TCPKeepAlive:
 
 stop-sshd:
   service.dead:
+    {%- if grains['os'] == 'Ubuntu' and grains['osmajorrelease'] >= 23 %}
+    - name: ssh
+    {%- else %}
     - name: sshd
+    {%- endif %}
     - enable: True
     - require:
       - ClientAliveInterval
@@ -49,7 +53,11 @@ stop-sshd:
 
 start-sshd:
   service.enabled:
+    {%- if grains['os'] == 'Ubuntu' and grains['osmajorrelease'] >= 23 %}
+    - name: ssh
+    {%- else %}
     - name: sshd
+    {%- endif %}
     - enable: True
     - reload: True
     - require:

--- a/golden-state-tree/python-pkgs/nox.sls
+++ b/golden-state-tree/python-pkgs/nox.sls
@@ -45,7 +45,7 @@
 nox:
   cmd.run:
   {%- if not on_windows %}
-    {%- if (grains['os'] == 'Debian' and grains['osmajorrelease'] >= 12) or grains['os'] == 'Arch' %}
+    {%- if (grains['os'] == 'Debian' and grains['osmajorrelease'] >= 12) or (grains['os'] == 'Ubuntu' and grains['osmajorrelease'] >= 23) or grains['os'] == 'Arch' %}
     - name: "{{ pip }} install 'nox=={{ nox_version }}' --break-system-packages"
     {%- else %}
     - name: "{{ pip }} install 'nox=={{ nox_version }}'"

--- a/os-images/AWS/ubuntu/ubuntu-20.04-arm64.pkrvars.hcl
+++ b/os-images/AWS/ubuntu/ubuntu-20.04-arm64.pkrvars.hcl
@@ -1,2 +1,3 @@
 ami_filter    = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-*"
 instance_type = "m6g.large"
+ami_owner     = "099720109477"

--- a/os-images/AWS/ubuntu/ubuntu-20.04-x86_64.pkrvars.hcl
+++ b/os-images/AWS/ubuntu/ubuntu-20.04-x86_64.pkrvars.hcl
@@ -1,2 +1,3 @@
 ami_filter    = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
 instance_type = "t3a.large"
+ami_owner     = "099720109477"

--- a/os-images/AWS/ubuntu/ubuntu-22.04-arm64.pkrvars.hcl
+++ b/os-images/AWS/ubuntu/ubuntu-22.04-arm64.pkrvars.hcl
@@ -1,2 +1,3 @@
 ami_filter    = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*"
 instance_type = "m6g.large"
+ami_owner     = "099720109477"

--- a/os-images/AWS/ubuntu/ubuntu-22.04-x86_64.pkrvars.hcl
+++ b/os-images/AWS/ubuntu/ubuntu-22.04-x86_64.pkrvars.hcl
@@ -1,2 +1,3 @@
 ami_filter    = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
 instance_type = "t3a.large"
+ami_owner     = "099720109477"

--- a/os-images/AWS/ubuntu/ubuntu-23.04-arm64.pkrvars.hcl
+++ b/os-images/AWS/ubuntu/ubuntu-23.04-arm64.pkrvars.hcl
@@ -1,0 +1,3 @@
+ami_filter    = "ubuntu/images/hvm-ssd/ubuntu-lunar-23.04-arm64-server-*"
+instance_type = "m6g.large"
+ami_owner     = "099720109477"

--- a/os-images/AWS/ubuntu/ubuntu-23.04-x86_64.pkrvars.hcl
+++ b/os-images/AWS/ubuntu/ubuntu-23.04-x86_64.pkrvars.hcl
@@ -1,0 +1,3 @@
+ami_filter    = "ubuntu/images/hvm-ssd/ubuntu-lunar-23.04-amd64-server-*"
+instance_type = "t3a.large"
+ami_owner     = "099720109477"


### PR DESCRIPTION
- Add Ubuntu 23.04 for amd64 and arm64
- Add `ami_owner` based on owner_id of images found in Ubuntu official EC2 image locator
  - https://cloud-images.ubuntu.com/locator/ec2/
- `pip` install of `nox` requires `--break-system-packages`  arg on Ubuntu 23.04 and newer
- OpenSSH service on Ubuntu 23.04 and greater is `ssh` instead of `sshd`