### PR TITLE
Disable PasswordAuthentication on Windows

### DIFF
--- a/os-images/AWS/windows/scripts/InstallAndConfigureOpenSSH.ps1
+++ b/os-images/AWS/windows/scripts/InstallAndConfigureOpenSSH.ps1
@@ -140,6 +140,7 @@ LogLevel DEBUG3
 '@
 # Un-comment below for debug logs
 #$SSHD_CONFIG_EXTRA | Out-File -Append -FilePath $SSHD_CONFIG -Encoding ASCII
+"PasswordAuthentication no" | Out-File -Append -FilePath $SSHD_CONFIG -Encoding ASCII
 
 # Ensure access control on administrators_authorized_keys meets the requirements
 $OPENSSH_UTILS_MODULE = [io.path]::combine($INSTALL_DIR, 'OpenSSHUtils.psd1')


### PR DESCRIPTION
- Sets `PasswordAuthentication no`
- This will prevent CI/CD hanging if authorized public key is not yet populated, as SSH will otherwise prompt for an Administrator password if `PasswordAuthentican yes`
  - Testing against Windows AMIs, we were finding that the authorized keys were sometimes taking a moment to get updated, and during this time SSH would prompt for the Administrator password. This is likely causing hangs in CI/CD when an SSH attempt is done too early against a Windows system