### PR TITLE
Windows scheduled jobs instead of tasks

### DIFF
--- a/os-images/AWS/windows/scripts/InstallAndConfigureOpenSSH.ps1
+++ b/os-images/AWS/windows/scripts/InstallAndConfigureOpenSSH.ps1
@@ -179,8 +179,6 @@ Write-Host "EC2 Instance Public Key Written To $openSSHAuthorizedKeys"
 # Ensure access control on administrators_authorized_keys meets the requirements
 Write-Host "Repairing permissions on $openSSHAuthorizedKeys"
 Repair-AdministratorsAuthorizedKeysPermission -FilePath $openSSHAuthorizedKeys -Confirm:$false
-
-Disable-ScheduledTask -TaskName "Download EC2 PubKey"
 '@
 $keyDownloadScript | Out-File $DOWNLOAD_KEYS_SCRIPT
 
@@ -190,15 +188,10 @@ $principal = New-ScheduledTaskPrincipal `
     -UserID "NT AUTHORITY\SYSTEM" `
     -LogonType ServiceAccount `
     -RunLevel Highest
-$action = New-ScheduledTaskAction -Execute 'Powershell.exe' `
-  -Argument "-NoProfile -File ""$DOWNLOAD_KEYS_SCRIPT"" -Verbose > c:\download-ec2-pubkey.log"
-$trigger =  New-ScheduledTaskTrigger -AtStartup
-Register-ScheduledTask -Action $action `
-    -Trigger $trigger `
-    -Principal $principal `
-    -TaskName $taskName `
-    -Description $taskName
-Disable-ScheduledTask -TaskName $taskName
+$jobtrigger = New-JobTrigger -AtStartup
+$joboptions = New-ScheduledJobOption -RunElevated
+Register-ScheduledJob -Name $taskName -Trigger $jobtrigger -FilePath "$DOWNLOAD_KEYS_SCRIPT" -ScheduledJobOption $joboptions
+Set-ScheduledTask -TaskName $taskName -Principal $principal
 
 # Run the download keys script, terminate if it fails
 & Powershell.exe -ExecutionPolicy Bypass -File $DOWNLOAD_KEYS_SCRIPT

--- a/os-images/AWS/windows/scripts/SysPrep.ps1
+++ b/os-images/AWS/windows/scripts/SysPrep.ps1
@@ -39,5 +39,5 @@ ElseIf (Test-Path $EC2ConfigDir) {
 Else {
   throw("Neither $EC2LaunchDir nor $EC2ConfigDir nor $EC2WindowsLaunch were found")
 }
-Enable-ScheduledTask "Download EC2 PubKey"
-Get-ScheduledTask | where state -eq 'Ready'
+Enable-ScheduledJob "Download EC2 PubKey"
+Get-ScheduledJob | where state -eq 'Ready'


### PR DESCRIPTION
Use scheduled jobs on Windows instead of scheduled tasks, for the benefit of additional logging retrievable: https://learn.microsoft.com/en-us/powershell/module/psscheduledjob/about/about_scheduled_jobs?view=powershell-5.1